### PR TITLE
Update setup.py

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,0 @@
-include pyfeng/data/ousv_benchmark.xlsx
-include pyfeng/data/heston_benchmark.xlsx
-include pyfeng/data/sabr_benchmark.xlsx

--- a/setup.py
+++ b/setup.py
@@ -19,4 +19,5 @@ setup(
     packages=["pyfeng"],
     test_suite="tests",
     install_requires=["numpy", "scipy"],
+    package_data={'pyfeng': ['data/*.xlsx']}
 )


### PR DESCRIPTION
To include `*.xlsx` data after pip install.

- Delete `MANIFEST.in`, since this only affects the source distribution package (referece: https://packaging.python.org/en/latest/guides/using-manifest-in/)
- Add package_data in `setup.py` to include the Excel data after pip install (reference: https://docs.python.org/3/distutils/setupscript.html#installing-package-data)