### PR TITLE
Fix abstract methods returning instead of raising NotImplementedError

### DIFF
--- a/pyfeng/heston_mc.py
+++ b/pyfeng/heston_mc.py
@@ -123,7 +123,7 @@ class HestonMcABC(heston.HestonABC, sv.CondMcBsmABC, abc.ABC):
         Returns:
             (variance after dt, average variance during dt)
         """
-        return NotImplementedError
+        raise NotImplementedError
 
     def cond_spot_sigma(self, texp, var_0):
         tobs = self.tobs(texp)

--- a/pyfeng/multiasset.py
+++ b/pyfeng/multiasset.py
@@ -69,7 +69,7 @@ class OptMaABC(opt.OptABC, abc.ABC):
         Returns:
             option price
         """
-        return NotImplementedError
+        raise NotImplementedError
 
 
 class BsmSpreadKirk(OptMaABC):

--- a/pyfeng/opt_abc.py
+++ b/pyfeng/opt_abc.py
@@ -90,7 +90,7 @@ class OptABC(abc.ABC):
         Returns:
             option price
         """
-        return NotImplementedError
+        raise NotImplementedError
 
     def impvol_brentq(self, price, strike, spot, texp, cp=1, setval=False):
         """
@@ -415,7 +415,7 @@ class OptAnalyticABC(OptABC):
         Returns:
             vanilla option price
         """
-        return NotImplementedError
+        raise NotImplementedError
 
     def price(self, strike, spot, texp, cp=1):
         if self.THROW_NEGATIVE_TEXP:
@@ -439,7 +439,7 @@ class OptAnalyticABC(OptABC):
         Returns:
             delta value
         """
-        return NotImplementedError
+        raise NotImplementedError
 
     @abc.abstractmethod
     def gamma(self, strike, spot, texp, cp=1):
@@ -455,7 +455,7 @@ class OptAnalyticABC(OptABC):
         Returns:
             gamma value
         """
-        return NotImplementedError
+        raise NotImplementedError
 
     @abc.abstractmethod
     def vega(self, strike, spot, texp, cp=1):
@@ -471,7 +471,7 @@ class OptAnalyticABC(OptABC):
         Returns:
             vega value
         """
-        return NotImplementedError
+        raise NotImplementedError
 
     @abc.abstractmethod
     def theta(self, strike, spot, texp, cp=1):
@@ -487,7 +487,7 @@ class OptAnalyticABC(OptABC):
         Returns:
             theta value
         """
-        return NotImplementedError
+        raise NotImplementedError
 
     @abc.abstractmethod
     def cdf(self, strike, spot, texp, cp=-1):
@@ -503,6 +503,6 @@ class OptAnalyticABC(OptABC):
         Returns:
             CDF value
         """
-        return NotImplementedError
+        raise NotImplementedError
 
 

--- a/pyfeng/opt_smile_abc.py
+++ b/pyfeng/opt_smile_abc.py
@@ -66,7 +66,7 @@ class MassZeroABC(opt.OptABC, abc.ABC):
         Returns:
             (log) probability mass at zero
         """
-        return NotImplementedError
+        raise NotImplementedError
 
     def vol_from_mass_zero(self, strike, spot, texp, mass=None):
         """

--- a/pyfeng/ousv.py
+++ b/pyfeng/ousv.py
@@ -301,7 +301,7 @@ class OusvMcABC(OusvABC, sv.CondMcBsmABC, abc.ABC):
         Returns:
             (final vol, average var, average vol)
         """
-        return NotImplementedError
+        raise NotImplementedError
 
     def vol_step(self, dt, vol_0, zn=None, nz_theta=True):
         """

--- a/pyfeng/rheston_mc.py
+++ b/pyfeng/rheston_mc.py
@@ -496,5 +496,5 @@ class RoughHestonMcMaWu2022(RoughHestonMcABC):
         return np.mean(price_, axis=1)
     
     def return_var_realized(self, texp, cond):
-        return NotImplementedError
+        raise NotImplementedError
         

--- a/pyfeng/sabr.py
+++ b/pyfeng/sabr.py
@@ -360,7 +360,7 @@ class SabrVolApproxABC(SabrABC):
         Returns:
             equivalent volatility
         """
-        return NotImplementedError
+        raise NotImplementedError
 
     def price(self, strike, spot, texp, cp=1):
         vol = self.vol_for_price(strike, spot, texp)

--- a/pyfeng/sabr_int.py
+++ b/pyfeng/sabr_int.py
@@ -46,7 +46,7 @@ class SabrMixtureABC(sabr.SabrABC, smile.MassZeroABC, abc.ABC):
     @abc.abstractmethod
     def cond_spot_sigma(self, texp, fwd):
         # return (fwd, vol, weight) each 1d array
-        return NotImplementedError
+        raise NotImplementedError
 
     def price(self, strike, spot, texp, cp=1):
         fwd = self.forward(spot, texp)

--- a/pyfeng/sabr_mc.py
+++ b/pyfeng/sabr_mc.py
@@ -48,7 +48,7 @@ class SabrMcABC(sabr.SabrABC, sv.CondMcBsmABC, abc.ABC):
         Returns:
             (sigma after dt, average variance during dt)
         """
-        return NotImplementedError
+        raise NotImplementedError
 
     def draw_log_return(self, dt, sigma_0, sigma_t, avgvar):
         """

--- a/pyfeng/subord_bm.py
+++ b/pyfeng/subord_bm.py
@@ -26,7 +26,7 @@ class SubordBmABC(sv.SvABC):
 
     @abc.abstractmethod
     def quad(self, texp, vov):
-        return NotImplementedError
+        raise NotImplementedError
 
     def price(self, strike, spot, texp, cp=1):
         fwd, df, _ = self._fwd_factor(spot, texp)

--- a/pyfeng/sv32_mc2.py
+++ b/pyfeng/sv32_mc2.py
@@ -35,7 +35,7 @@ class Sv32McABC(sv.SvABC, sv.CondMcBsmABC, abc.ABC):
         Returns:
             (var_t, avgvar)
         """
-        return NotImplementedError
+        raise NotImplementedError
 
     @staticmethod
     def iv_complex(nu, zz):

--- a/pyfeng/sv_abc.py
+++ b/pyfeng/sv_abc.py
@@ -216,7 +216,7 @@ class CondMcBsmABC(smile.OptSmileABC, abc.ABC):
 
         Returns: (forward, volatility)
         """
-        return NotImplementedError
+        raise NotImplementedError
 
 
     def price(self, strike, spot, texp, cp=1):
@@ -242,7 +242,7 @@ class CondMcBsmABC(smile.OptSmileABC, abc.ABC):
 
     @abc.abstractmethod
     def return_var_realized(self, texp, cond):
-        return NotImplementedError
+        raise NotImplementedError
 
     def price_var_opt(self, strike, texp, cp=1):
         """
@@ -323,7 +323,7 @@ class SvMixtureABC(smile.OptSmileABC, abc.ABC):
 
         Returns: (spot, volatility, weight)
         """
-        return NotImplementedError
+        raise NotImplementedError
 
     def price(self, strike, spot, texp, cp=1):
 

--- a/pyfeng/sv_fft.py
+++ b/pyfeng/sv_fft.py
@@ -29,7 +29,7 @@ class FftABC(opt.OptABC, abc.ABC):
         Returns:
             MGF value at uu
         """
-        return NotImplementedError
+        raise NotImplementedError
 
     def charfunc_logprice(self, x, texp):
         """


### PR DESCRIPTION
All 21 occurrences of `return NotImplementedError` replaced with `raise NotImplementedError` across 13 files. Previously, calling an unimplemented abstract method would silently return the exception class object rather than raising, making bugs nearly impossible to diagnose.