### PR TITLE
Implement Oosterlee & Fang Fourier-Cosine Method

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ derivative pricing.
 ## Implemented Models 
   * Black-Scholes-Merton (BSM) and displaced BSM models:
     * Analytic option price, Greeks, and implied volatility.
+    * Cosine-FT option pricing.
   * Bachelier (Normal) model
     * Analytic option price, Greeks, and implied volatility.
   * Constant-elasticity-of-variance (CEV) model
@@ -23,6 +24,10 @@ derivative pricing.
   * Heston model
     * FFT option pricing.
     * Almost exact MC simulation by Glasserman & Kim and Choi & Kwok.
+    * Cosine-FT option pricing. 
+  * Variance Gamma (VG) model
+    * FFT option pricing.
+    * Cosine-FT option pricing.
   * Schobel-Zhu (OUSV) model
     * FFT option pricing.
     * Almost exact MC simulation by Choi

--- a/pyfeng/__init__.py
+++ b/pyfeng/__init__.py
@@ -10,6 +10,9 @@ from .gamma import InvGam, InvGauss
 # FFT related models
 from .sv_fft import HestonFft, BsmFft, OusvFft, VarGammaFft, CgmyFft, ExpNigFft, Sv32Fft, GarchFftWuMaWang2012
 
+# COS (Fourier-Cosine) method
+from .sv_cos import BsmCos, HestonCos, VarGammaCos
+
 # SABR/NSVh related models
 from .sabr import SabrHagan2002, SabrNormVolApprox, SabrLorig2017, SabrChoiWu2021H, SabrChoiWu2021P
 from .sabr_int import SabrUncorrChoiWu2021, SabrNormAnalytic, SabrNormEllipeInt, SabrMixture

--- a/pyfeng/sv_cos.py
+++ b/pyfeng/sv_cos.py
@@ -1,0 +1,370 @@
+"""
+European option pricing via the Fourier-Cosine (COS) method.
+
+References:
+    Fang F, Oosterlee CW (2008) A Novel Pricing Method for European Options
+    Based on Fourier-Cosine Series Expansions.
+    SIAM Journal on Scientific Computing 31(2):826-848.
+    https://doi.org/10.1137/080718061
+"""
+
+import abc
+import numpy as np
+from . import opt_abc as opt
+from . import sv_abc as sv
+from . import heston
+
+
+class CosABC(opt.OptABC, abc.ABC):
+    """
+    Abstract base class for European option pricing via the Fourier-Cosine
+    (COS) method of Fang & Oosterlee (2008).
+
+    Subclasses must implement ``mgf_logprice(uu, texp)`` – the moment
+    generating function of log(S_T / F) where F is the forward price.
+    The same interface is used by ``FftABC`` so model-level MGF
+    implementations (e.g. ``HestonFft``) are directly reusable.
+
+    Attributes:
+        n_cos (int): Number of Fourier-cosine terms N (default 128).
+                     Increase for higher accuracy or extreme parameters.
+        L (float): Truncation-range half-width multiplier (default 12).
+    """
+
+    n_cos: int = 128
+    L: float = 12.0
+
+    @abc.abstractmethod
+    def mgf_logprice(self, uu, texp):
+        """
+        Moment generating function (MGF) of log(S_T / F).
+
+        Args:
+            uu: argument – scalar or array, real or complex.
+            texp: time to expiry.
+
+        Returns:
+            MGF values with the same shape as *uu*.
+        """
+        raise NotImplementedError
+
+    def charfunc_logprice(self, u, texp):
+        """Characteristic function phi(u) = MGF(i*u)."""
+        return self.mgf_logprice(1j * u, texp)
+
+    # ------------------------------------------------------------------
+    # Cumulants and truncation range
+    # ------------------------------------------------------------------
+
+    def _cumulants(self, texp):
+        """
+        First four cumulants of log(S_T/F) via numerical differentiation
+        of log MGF at real arguments.  Subclasses override with analytic
+        formulas where available.
+
+        Returns:
+            (c1, c2, c3, c4)
+        """
+        eps = 1e-3
+        lm = lambda v: float(np.log(self.mgf_logprice(v, texp)).real)
+        lm0 = lm(0.0)
+        lmp1, lmm1 = lm(eps), lm(-eps)
+        lmp2, lmm2 = lm(2*eps), lm(-2*eps)
+        c1 = (lmp1 - lmm1) / (2*eps)
+        c2 = (lmp1 + lmm1 - 2*lm0) / eps**2
+        c4 = (lmp2 - 4*lmp1 + 6*lm0 - 4*lmm1 + lmm2) / eps**4
+        return c1, c2, 0.0, c4
+
+    def _truncation_range(self, texp):
+        """
+        Integration interval [a, b] from Eq. (5.2) of Fang & Oosterlee.
+
+        Returns:
+            (a, b) floats
+        """
+        c1, c2, _, c4 = self._cumulants(texp)
+        half = self.L * np.sqrt(abs(c2) + np.sqrt(abs(c4)))
+        return c1 - half, c1 + half
+
+    # ------------------------------------------------------------------
+    # Payoff coefficient helpers (Eqs. 22-23)
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _chi(k, u, a, c, d):
+        """
+        Eq. (22): integral from c to d of exp(x) * cos(k*pi*(x-a)/(b-a)) dx
+
+        Broadcasting convention: u has shape (1, N), c and d have
+        shape (M, 1) so the result has shape (M, N).
+        """
+        exp_d, exp_c = np.exp(d), np.exp(c)
+        cos_d = np.cos(u * (d - a))
+        cos_c = np.cos(u * (c - a))
+        sin_d = np.sin(u * (d - a))
+        sin_c = np.sin(u * (c - a))
+        num = cos_d*exp_d - cos_c*exp_c + u*(sin_d*exp_d - sin_c*exp_c)
+        return num / (1.0 + u**2)
+
+    @staticmethod
+    def _psi(k, u, a, c, d):
+        """
+        Eq. (23): integral from c to d of cos(k*pi*(x-a)/(b-a)) dx.
+        k=0 handled separately to avoid division by zero.
+        """
+        safe_u = np.where(k == 0, 1.0, u)
+        return np.where(
+            k == 0,
+            d - c,
+            (np.sin(u * (d - a)) - np.sin(u * (c - a))) / safe_u
+        )
+
+    # ------------------------------------------------------------------
+    # Pricing
+    # ------------------------------------------------------------------
+
+    def price(self, strike, spot, texp, cp=1):
+        """
+        European call/put price via the COS method.
+
+        Fully vectorised over *strike* and *cp*. The dominant cost is
+        one (M x N) matrix-vector multiply, where M = len(strikes)
+        and N = self.n_cos.
+
+        Args:
+            strike: strike price(s) - scalar or array shape (M,).
+            spot:   spot (or forward if ``is_fwd=True``) price.
+            texp:   time to expiry.
+            cp:     +1 call / -1 put (scalar or array matching strike).
+
+        Returns:
+            Option price(s) matching the broadcast shape of (strike, cp).
+        """
+        fwd, df, _ = self._fwd_factor(spot, texp)
+
+        scalar_out = np.isscalar(strike) and np.isscalar(cp)
+        kk   = np.atleast_1d(np.asarray(strike / fwd, dtype=float))   # (M,)
+        cp_a = np.broadcast_to(
+            np.atleast_1d(np.asarray(cp, dtype=float)), kk.shape
+        ).copy()
+
+        a, b = self._truncation_range(texp)
+        ba   = b - a
+
+        k_arr = np.arange(self.n_cos)          # (N,)
+        u_arr = k_arr * np.pi / ba             # (N,)
+
+        # Characteristic function with phase shift exp(-i*u*a)
+        cf   = self.charfunc_logprice(u_arr, texp)   # (N,) complex
+        cf_s = cf * np.exp(-1j * u_arr * a)
+        cf_s[0] *= 0.5                               # prime-sum (k=0 gets 1/2)
+        cf_re = cf_s.real                            # (N,)
+
+        # Payoff coefficients - shape (M, N)
+        log_kk = np.clip(np.log(kk), a, b)[:, None] # (M, 1)
+        u  = u_arr[None, :]                          # (1, N)
+        k  = k_arr[None, :]                          # (1, N)
+        kk_c = kk[:, None]                           # (M, 1)
+
+        # Call:  (2/ba) * [ chi(log_kk, b) - K/F * psi(log_kk, b) ]
+        W_call = (2.0 / ba) * (
+            self._chi(k, u, a, log_kk, b) - kk_c * self._psi(k, u, a, log_kk, b)
+        )
+        # Put:   (2/ba) * [ K/F * psi(a, log_kk) - chi(a, log_kk) ]
+        W_put = (2.0 / ba) * (
+            kk_c * self._psi(k, u, a, a, log_kk) - self._chi(k, u, a, a, log_kk)
+        )
+
+        W = np.where(cp_a[:, None] > 0, W_call, W_put)   # (M, N)
+
+        price_arr = df * fwd * (W @ cf_re)                 # (M,)
+
+        if scalar_out:
+            return float(price_arr[0])
+        return price_arr.reshape(
+            np.broadcast_shapes(np.shape(strike), np.shape(cp))
+        )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Black-Scholes-Merton (included for cross-validation; not exported)
+# ─────────────────────────────────────────────────────────────────────────────
+
+class BsmCos(CosABC):
+    """
+    Black-Scholes-Merton European option pricing via the COS method.
+
+    Uses analytic BSM cumulants (c4 = 0), giving a tight truncation range
+    and near machine-precision accuracy for N >= 64.
+
+    Examples:
+        >>> import numpy as np
+        >>> import pyfeng as pf
+        >>> m = pf.BsmCos(sigma=0.2, intr=0.05, divr=0.1)
+        >>> m.price(np.arange(80, 121, 10), 100, 1.2)
+        array([15.71361973,  9.69250803,  5.52948546,  2.94558338,  1.48139131])
+    """
+
+    def mgf_logprice(self, uu, texp):
+        """BSM log-price MGF: exp(-0.5 * sigma^2 * T * u * (1 - u))."""
+        return np.exp(-0.5 * self.sigma**2 * texp * uu * (1.0 - uu))
+
+    def _cumulants(self, texp):
+        """Exact BSM cumulants. c4 = 0 -> minimal truncation range."""
+        s2t = self.sigma**2 * texp
+        return -0.5 * s2t, s2t, 0.0, 0.0
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Heston stochastic-volatility model
+# ─────────────────────────────────────────────────────────────────────────────
+
+class HestonCos(heston.HestonABC, CosABC):
+    """
+    Heston (1993) stochastic-volatility model: European option pricing
+    via the COS method of Fang & Oosterlee (2008).
+
+    Parameters (PyFENG ``SvABC`` convention):
+        sigma  - initial variance V0
+        vov    - vol-of-vol (eta)
+        mr     - mean-reversion speed (kappa)
+        rho    - correlation (rho)
+        theta  - long-run variance V-bar (defaults to sigma)
+
+    The CF uses the Lord-Kahl (2010) branch-cut-safe formulation,
+    identical to ``HestonFft``, so both pricers can be cross-validated.
+    Analytic cumulants from F&O (2008) Appendix A set the truncation
+    range. For parameters violating the Feller condition (2*kappa*V-bar
+    < eta^2) or maturities T > 5, increase ``n_cos`` (e.g. ``m.n_cos = 512``).
+
+    Examples:
+        >>> import numpy as np
+        >>> import pyfeng as pf
+        >>> sigma, vov, mr, rho, texp, spot = 0.04, 0.5, 1.5, -0.7, 1.0, 100
+        >>> m = pf.HestonCos(sigma, vov=vov, mr=mr, rho=rho)
+        >>> m.price(np.array([90, 95, 100, 105, 110]), spot, texp)
+
+    References:
+        - Heston SL (1993) Rev. Financial Studies 6:327-343.
+        - Lord R, Kahl C (2010) Mathematical Finance 20:671-694.
+        - Fang F, Oosterlee CW (2008) SIAM J. Sci. Comput. 31:826-848.
+    """
+
+    def mgf_logprice(self, uu, texp):
+        """
+        Heston log-price MGF – Lord & Kahl (2010) branch-cut-safe formulation.
+        Matches HestonFft.mgf_logprice exactly (same variable names and style).
+
+        References:
+            - Lord R, Kahl C (2010) Complex Logarithms in Heston-Like Models.
+              Mathematical Finance 20:671-694.
+        """
+        var_0 = self.sigma
+        vov2 = self.vov**2
+
+        beta = self.mr - self.vov*self.rho*uu
+        dd = np.sqrt(beta**2 + vov2*uu*(1 - uu))
+        gg = (beta - dd)/(beta + dd)
+        exp = np.exp(-dd*texp)
+        tmp1 = 1 - gg*exp
+
+        mgf = self.mr*self.theta*((beta - dd)*texp - 2*np.log(tmp1/(1 - gg))) + var_0*(beta - dd)*(1 - exp)/tmp1
+        return np.exp(mgf/vov2)
+
+    def _cumulants(self, texp):
+        """
+        Analytic cumulants of log(S_T/F) for the Heston model.
+
+        c1 uses HestonABC.avgvar_mv (Ball & Roma 1994 Appendix B).
+        c2 follows Appendix A, Eq. (A.2) of Fang & Oosterlee (2008)
+        and includes the rho term (avgvar_mv does not cover this).
+        c4 is set to zero per F&O Section 5, keeping [a, b] well-conditioned.
+
+        Returns:
+            (c1, c2, 0.0, 0.0)
+        """
+        kap = self.mr
+        eta = self.vov
+        lam = self.theta
+        v0  = self.sigma
+        T   = texp
+
+        # c1: -1/2 * E[integrated variance] — uses HestonABC helper
+        c1 = -0.5 * texp * self.avgvar_mv(texp)[0]
+
+        eT  = np.exp(-kap * T)
+        e2T = np.exp(-2.0 * kap * T)
+
+        # c2: Appendix A, Eq. (A.2) of Fang & Oosterlee (2008)
+        c2 = (1.0 / (8.0 * kap**3)) * (
+            eta * T * kap * eT * (v0 - lam) * (8.0 * kap * self.rho - 4.0 * eta)
+          + kap * self.rho * eta * (1.0 - eT) * (16.0 * lam - 8.0 * v0)
+          + 2.0 * lam * kap * T * (-4.0 * kap * self.rho * eta + eta**2 + 4.0 * kap**2)
+          + eta**2 * ((lam - 2.0*v0)*e2T + lam*(6.0*eT - 7.0) + 2.0*v0)
+          + 8.0 * kap**2 * (v0 - lam) * (1.0 - eT)
+        )
+
+        return float(c1), float(abs(c2)), 0.0, 0.0
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Variance Gamma model
+# ─────────────────────────────────────────────────────────────────────────────
+
+class VarGammaCos(sv.SvABC, CosABC):
+    """
+    Variance Gamma (VG) European option pricing via the COS method.
+
+    The VG model subordinates a drifted Brownian motion to a Gamma clock:
+        log(S_T/F) = w*T + theta*G_T + sigma*W_{G_T}
+    where G_T ~ Gamma(T/nu, nu) and w = (1/nu)*log(1 - theta*nu - sigma^2*nu/2)
+    is the martingale drift correction.
+
+    Parameter convention matches ``VarGammaFft`` (same SvABC names):
+        sigma  - volatility of the Brownian subordinate (sigma)
+        vov    - Gamma clock variance rate (nu > 0)
+        theta  - drift of the Brownian subordinate (controls skewness;
+                 defaults to sigma if not set)
+        rho    - not used (inherited from SvABC)
+        mr     - not used (inherited from SvABC)
+
+    Examples:
+        >>> import numpy as np
+        >>> import pyfeng as pf
+        >>> m = pf.VarGammaCos(sigma=0.12, vov=0.2, theta=-0.14, intr=0.1)
+        >>> m.price(np.arange(80, 121, 10), 100, 1.0)
+
+    References:
+        Fang F, Oosterlee CW (2008) SIAM J. Sci. Comput. 31:826-848,
+        Section 5.4, Eq. (31) and Table 11.
+        Madan D, Carr P, Chang E (1998) The Variance Gamma Process and Option Pricing.
+        European Finance Review 2:79-105.
+    """
+
+    def mgf_logprice(self, uu, texp):
+        """
+        VG log-price MGF from F&O (2008) Eq. (31).
+        Matches VarGammaFft.mgf_logprice formula (in-place exp rewritten for clarity).
+
+        M(s) = exp(s*w*T) / (1 - s*theta*nu - 0.5*s^2*sigma^2*nu)^(T/nu)
+        """
+        nu = self.vov
+        volvar = nu * self.sigma**2
+        mu = np.log(1 - self.theta*nu - 0.5*volvar)    # = nu * martingale correction w
+        rv = mu*uu - np.log(1 + (-self.theta*nu - 0.5*volvar*uu)*uu)
+        return np.exp(texp/nu * rv)
+
+    def _cumulants(self, texp):
+        """
+        Analytic VG cumulants from F&O (2008) Table 11.
+
+        Returns:
+            (c1, c2, 0.0, c4)
+        """
+        nu   = self.vov
+        sig2 = self.sigma**2
+        w    = np.log(1 - self.theta*nu - 0.5*sig2*nu) / nu
+        c1   = texp * (w + self.theta)
+        c2   = (sig2 + nu*self.theta**2) * texp
+        c4   = 3*(sig2**2*nu + 2*self.theta**4*nu**3 + 4*sig2*self.theta**2*nu**2) * texp
+        return float(c1), float(abs(c2)), 0.0, float(abs(c4))

--- a/tests/test_cos.py
+++ b/tests/test_cos.py
@@ -1,0 +1,278 @@
+import unittest
+import numpy as np
+import sys
+import os
+
+sys.path.insert(0, os.getcwd())
+import pyfeng as pf
+
+
+class TestBsmCos(unittest.TestCase):
+    """
+    Tests for Black-Scholes COS pricer (BsmCos).
+
+    BsmCos uses exact analytic cumulants so its truncation range is tight
+    and accuracy vs the closed-form Bsm should be near machine precision.
+    """
+
+    strikes = np.arange(80., 121., 10.)   # [80, 90, 100, 110, 120]
+    spot    = 100.
+    sigma, intr, divr = 0.2, 0.05, 0.1
+
+    def test_vs_analytic(self):
+        """BsmCos matches closed-form Bsm to within 1e-10 for calls and puts."""
+        cos = pf.BsmCos(self.sigma, intr=self.intr, divr=self.divr)
+        ref = pf.Bsm(self.sigma,    intr=self.intr, divr=self.divr)
+        for texp in [0.5, 1.2, 3.0]:
+            for cp in [1, -1]:
+                np.testing.assert_allclose(
+                    cos.price(self.strikes, self.spot, texp, cp=cp),
+                    ref.price(self.strikes, self.spot, texp, cp=cp),
+                    atol=1e-10,
+                    err_msg=f"texp={texp}, cp={cp}",
+                )
+
+    def test_reference_values(self):
+        """Pin prices to the values from the BsmCos docstring example."""
+        m      = pf.BsmCos(0.2, intr=0.05, divr=0.1)
+        result = m.price(np.arange(80., 121., 10.), 100., 1.2)
+        expect = np.array([15.71361973, 9.69250803, 5.52948546, 2.94558338, 1.48139131])
+        np.testing.assert_allclose(result, expect, atol=1e-7)
+
+    def test_put_call_parity(self):
+        """C - P = df * (F - K) to within 1e-12."""
+        m = pf.BsmCos(self.sigma, intr=self.intr, divr=self.divr)
+        for texp in [0.5, 1.2, 3.0]:
+            C = m.price(self.strikes, self.spot, texp, cp=1)
+            P = m.price(self.strikes, self.spot, texp, cp=-1)
+            fwd, df, _ = m._fwd_factor(self.spot, texp)
+            np.testing.assert_allclose(
+                C - P, df * (fwd - self.strikes), atol=1e-12,
+                err_msg=f"texp={texp}",
+            )
+
+    def test_scalar_in_scalar_out(self):
+        """Scalar strike and scalar cp must return a Python float."""
+        m = pf.BsmCos(self.sigma, intr=self.intr, divr=self.divr)
+        p = m.price(100., self.spot, 1.0, cp=1)
+        self.assertIsInstance(p, float)
+
+    def test_array_output_shape(self):
+        """Output shape matches the input strikes array."""
+        m = pf.BsmCos(self.sigma, intr=self.intr, divr=self.divr)
+        p = m.price(self.strikes, self.spot, 1.0)
+        self.assertEqual(p.shape, self.strikes.shape)
+
+    def test_is_fwd(self):
+        """is_fwd=True treats spot as the forward; prices must be identical."""
+        m_spot = pf.BsmCos(self.sigma, intr=self.intr, divr=self.divr, is_fwd=False)
+        m_fwd  = pf.BsmCos(self.sigma, intr=self.intr,                  is_fwd=True)
+        fwd_val = m_spot.forward(self.spot, 1.2)
+        np.testing.assert_allclose(
+            m_spot.price(self.strikes, self.spot,   1.2),
+            m_fwd.price( self.strikes, fwd_val,     1.2),
+            atol=1e-10,
+        )
+
+    def test_default_n_cos_and_L(self):
+        """Class-level defaults for n_cos and L are set correctly."""
+        m = pf.BsmCos(self.sigma)
+        self.assertEqual(m.n_cos, 128)
+        self.assertEqual(m.L, 12.0)
+
+
+class TestHestonCos(unittest.TestCase):
+    """
+    Tests for Heston COS pricer (HestonCos).
+
+    HestonCos uses the same Lord-Kahl (2010) MGF as HestonFft and analytic
+    cumulants from Fang & Oosterlee (2008) Appendix A. Cross-validation
+    against HestonFft is the primary accuracy check (atol = 5e-4).
+    """
+
+    strikes        = np.array([80., 90., 100., 110., 120.])
+    spot           = 100.
+    sigma, vov, mr, rho = 0.04, 0.5, 1.5, -0.7   # primary benchmark params
+
+    def _cos(self, **kw):
+        return pf.HestonCos(self.sigma, vov=self.vov, mr=self.mr, rho=self.rho, **kw)
+
+    def _fft(self, **kw):
+        return pf.HestonFft(self.sigma, vov=self.vov, mr=self.mr, rho=self.rho, **kw)
+
+    def test_vs_fft(self):
+        """HestonCos agrees with HestonFft to within 5e-4 across maturities."""
+        cos, fft = self._cos(), self._fft()
+        for texp in [0.5, 1.0, 5.0, 10.0]:
+            for cp in [1, -1]:
+                np.testing.assert_allclose(
+                    cos.price(self.strikes, self.spot, texp, cp=cp),
+                    fft.price(self.strikes, self.spot, texp, cp=cp),
+                    atol=5e-4,
+                    err_msg=f"texp={texp}, cp={cp}",
+                )
+
+    def test_vs_fft_multiple_param_sets(self):
+        """Cross-validate for varied Heston parameters (different rho, vov, mr)."""
+        param_sets = [
+            dict(sigma=0.09, vov=0.3, mr=4.0, rho=0.0),   # Feller satisfied, no corr
+            dict(sigma=0.04, vov=0.5, mr=2.0, rho=0.5),   # positive correlation
+            dict(sigma=0.06, vov=0.4, mr=1.0, rho=-0.5),  # moderate parameters
+        ]
+        for params in param_sets:
+            cos = pf.HestonCos(**params)
+            fft = pf.HestonFft(**params)
+            np.testing.assert_allclose(
+                cos.price(self.strikes, self.spot, 1.0),
+                fft.price(self.strikes, self.spot, 1.0),
+                atol=5e-4,
+                err_msg=f"params={params}",
+            )
+
+    def test_put_call_parity(self):
+        """C - P = df*(F-K) within 5e-4 (bounded by truncation-range residual)."""
+        cos = self._cos()
+        for texp in [0.5, 1.0, 3.0]:
+            C = cos.price(self.strikes, self.spot, texp, cp=1)
+            P = cos.price(self.strikes, self.spot, texp, cp=-1)
+            fwd, df, _ = cos._fwd_factor(self.spot, texp)
+            np.testing.assert_allclose(
+                C - P, df * (fwd - self.strikes), atol=5e-4,
+                err_msg=f"texp={texp}",
+            )
+
+    def test_convergence_in_n(self):
+        """Pricing error vs HestonFft strictly decreases as n_cos increases."""
+        ref = self._fft().price(self.strikes, self.spot, 1.0)
+
+        m_64, m_256 = self._cos(), self._cos()
+        m_64.n_cos, m_256.n_cos = 64, 256
+
+        err_64  = np.max(np.abs(m_64.price( self.strikes, self.spot, 1.0) - ref))
+        err_256 = np.max(np.abs(m_256.price(self.strikes, self.spot, 1.0) - ref))
+        self.assertLess(err_256, err_64)
+
+    def test_scalar_in_scalar_out(self):
+        """Scalar strike + scalar cp returns a Python float."""
+        p = self._cos().price(100., self.spot, 1.0, cp=1)
+        self.assertIsInstance(p, float)
+
+    def test_array_output_shape(self):
+        """Output shape matches the strikes array."""
+        p = self._cos().price(self.strikes, self.spot, 1.0)
+        self.assertEqual(p.shape, self.strikes.shape)
+
+    def test_nonnegative_prices(self):
+        """Call and put prices are non-negative for all strikes."""
+        cos = self._cos()
+        for cp in [1, -1]:
+            p = cos.price(self.strikes, self.spot, 1.0, cp=cp)
+            np.testing.assert_(np.all(p >= 0), f"Negative prices for cp={cp}")
+
+    def test_theta_defaults_to_sigma(self):
+        """When theta is omitted, HestonCos inherits SvABC default theta=sigma."""
+        m = self._cos()
+        self.assertEqual(m.theta, m.sigma)
+
+    def test_n_cos_instance_override(self):
+        """n_cos can be overridden on an instance; setting it changes results."""
+        m = self._cos()
+        self.assertEqual(m.n_cos, 128)          # class-level default
+        p_128 = m.price(self.strikes, self.spot, 1.0)
+        m.n_cos = 32
+        p_32 = m.price(self.strikes, self.spot, 1.0)
+        # n_cos=32 is too coarse — result should differ from n_cos=128
+        self.assertFalse(np.allclose(p_32, p_128, atol=1e-8))
+
+
+class TestVarGammaCos(unittest.TestCase):
+    """
+    Tests for Variance Gamma COS pricer (VarGammaCos).
+
+    Uses the same SvABC parameter convention as VarGammaFft:
+        sigma = Brownian vol, vov = Gamma clock variance rate (nu), theta = drift.
+    Cross-validation against VarGammaFft is the primary accuracy check.
+    """
+
+    strikes = np.array([80., 90., 100., 110., 120.])
+    spot    = 100.
+    # F&O (2008) Section 5.4 parameters
+    sigma, vov, theta, intr = 0.12, 0.2, -0.14, 0.1
+
+    def _cos(self, **kw):
+        return pf.VarGammaCos(self.sigma, vov=self.vov, theta=self.theta,
+                               intr=self.intr, **kw)
+
+    def _fft(self, **kw):
+        return pf.VarGammaFft(self.sigma, vov=self.vov, theta=self.theta,
+                               intr=self.intr, **kw)
+
+    def test_vs_fft(self):
+        """VarGammaCos agrees with VarGammaFft to within 5e-4."""
+        cos, fft = self._cos(), self._fft()
+        for texp in [0.5, 1.0, 2.0]:
+            np.testing.assert_allclose(
+                cos.price(self.strikes, self.spot, texp),
+                fft.price(self.strikes, self.spot, texp),
+                atol=5e-4,
+                err_msg=f"texp={texp}",
+            )
+
+    def test_put_call_parity(self):
+        """C - P = df*(F-K) to within 1e-5."""
+        cos = self._cos()
+        for texp in [0.5, 1.0, 2.0]:
+            C = cos.price(self.strikes, self.spot, texp, cp=1)
+            P = cos.price(self.strikes, self.spot, texp, cp=-1)
+            fwd, df, _ = cos._fwd_factor(self.spot, texp)
+            np.testing.assert_allclose(
+                C - P, df * (fwd - self.strikes), atol=1e-5,
+                err_msg=f"texp={texp}",
+            )
+
+    def test_convergence_in_n(self):
+        """Pricing error vs VarGammaFft strictly decreases as n_cos increases."""
+        ref = self._fft().price(self.strikes, self.spot, 1.0)
+
+        m_64, m_256 = self._cos(), self._cos()
+        m_64.n_cos, m_256.n_cos = 64, 256
+
+        err_64  = np.max(np.abs(m_64.price( self.strikes, self.spot, 1.0) - ref))
+        err_256 = np.max(np.abs(m_256.price(self.strikes, self.spot, 1.0) - ref))
+        self.assertLess(err_256, err_64)
+
+    def test_scalar_in_scalar_out(self):
+        """Scalar strike + scalar cp returns a Python float."""
+        p = self._cos().price(100., self.spot, 1.0, cp=1)
+        self.assertIsInstance(p, float)
+
+    def test_array_output_shape(self):
+        """Output shape matches the strikes array."""
+        p = self._cos().price(self.strikes, self.spot, 1.0)
+        self.assertEqual(p.shape, self.strikes.shape)
+
+    def test_nonnegative_prices(self):
+        """Call and put prices are non-negative for all strikes."""
+        cos = self._cos()
+        for cp in [1, -1]:
+            p = cos.price(self.strikes, self.spot, 1.0, cp=cp)
+            np.testing.assert_(np.all(p >= 0), f"Negative prices for cp={cp}")
+
+    def test_call_decreasing_in_strike(self):
+        """Call prices must decrease monotonically with strike (no-arbitrage)."""
+        cos = self._cos()
+        C = cos.price(self.strikes, self.spot, 1.0, cp=1)
+        np.testing.assert_(np.all(np.diff(C) < 0),
+                            "Call prices are not monotonically decreasing in strike")
+
+    def test_put_increasing_in_strike(self):
+        """Put prices must increase monotonically with strike (no-arbitrage)."""
+        cos = self._cos()
+        P = cos.price(self.strikes, self.spot, 1.0, cp=-1)
+        np.testing.assert_(np.all(np.diff(P) > 0),
+                            "Put prices are not monotonically increasing in strike")
+
+
+if __name__ == "__main__":
+    print(f"Pyfeng loaded from {pf.__path__}")
+    unittest.main()


### PR DESCRIPTION
Resolves #127 . This integrates the code from our team's [repository for implementing Oosterlee and Fang's Fourier-Cosine Method](https://github.com/ee2625/fourier-cosine-option-pricing). A separate PR to PyFengForPapers will be made to show the implementations. 

This also updates the Readme to be more up to date as the Variance Gamma method was already in the FFT AND was used in the paper