### PR TITLE
Critical Fixes by Claude

### DIFF
--- a/pyfeng/assetalloc.py
+++ b/pyfeng/assetalloc.py
@@ -1,4 +1,5 @@
 import abc
+import warnings
 import numpy as np
 import scipy.stats as spst
 import scipy.optimize as spop
@@ -40,7 +41,8 @@ class AssetAllocABC(abc.ABC):
                              + (1 - cor) * np.eye(self.n_asset)
                 self.rho = cor
             else:
-                assert cor.shape == (self.n_asset, self.n_asset)
+                if cor.shape != (self.n_asset, self.n_asset):
+                    raise ValueError(f"cor must have shape ({self.n_asset}, {self.n_asset}), got {cor.shape}.")
                 self.cor_m = cor
                 if self.n_asset == 2:
                     self.rho = cor[0, 1]
@@ -64,7 +66,8 @@ class AssetAllocABC(abc.ABC):
         elif np.isscalar(longshort):
             self.longshort = np.full(self.n_asset, np.sign(longshort), dtype=np.int8)  # long-only
         else:
-            assert self.n_asset == len(longshort)
+            if self.n_asset != len(longshort):
+                raise ValueError(f"longshort length {len(longshort)} does not match n_asset={self.n_asset}.")
             self.longshort = np.sign(longshort, dtype=np.int8)  # long-only
 
 
@@ -121,8 +124,10 @@ class RiskParity(AssetAllocABC):
         if budget is None:
             self.budget = np.full(self.n_asset, 1 / self.n_asset)
         else:
-            assert self.n_asset == len(budget)
-            assert np.isclose(np.sum(budget), 1)
+            if self.n_asset != len(budget):
+                raise ValueError(f"budget length {len(budget)} does not match n_asset={self.n_asset}.")
+            if not np.isclose(np.sum(budget), 1):
+                raise ValueError(f"budget must sum to 1, got {np.sum(budget)}.")
             self.budget = np.array(budget)
 
     @classmethod
@@ -142,7 +147,8 @@ class RiskParity(AssetAllocABC):
         ev[:n_asset-zero_ev] = np.random.uniform(size=n_asset - zero_ev)
         ev *= n_asset / np.sum(ev)
         cor = spst.random_correlation.rvs(ev, tol=1e-11)
-        assert np.allclose(np.diag(cor), 1)
+        if not np.allclose(np.diag(cor), 1):
+            raise ValueError("Correlation matrix diagonal must be all ones.")
 
         m = cls(cov=cor)
         return m
@@ -261,7 +267,7 @@ class RiskParity(AssetAllocABC):
         sol = spop.root(self._newton_val, w_init, (cor, self.budget), jac=self._newton_jacobian, tol=tol)
         # assert sol.success
         if not sol.success:
-            print("Newton Failed.")
+            warnings.warn("Newton solver failed to converge.")
 
         ww = sol.x / self.sigma
         ww /= np.sum(ww)

--- a/pyfeng/garch.py
+++ b/pyfeng/garch.py
@@ -1,3 +1,4 @@
+import warnings
 import numpy as np
 from . import sv_abc as sv
 from . import bsm
@@ -63,7 +64,7 @@ class GarchUncorrBaroneAdesi2004(sv.SvABC):
     def price(self, strike, spot, texp, cp=1):
 
         if not np.isclose(self.rho, 0.0):
-            print(f"Pricing ignores rho = {self.rho}.")
+            warnings.warn(f"Pricing ignores rho = {self.rho}.")
 
         avgvar, var = self.avgvar_mv(texp, self.sigma)
 

--- a/pyfeng/heston.py
+++ b/pyfeng/heston.py
@@ -1,4 +1,5 @@
 import abc
+import warnings
 import numpy as np
 from . import sv_abc as sv
 from . import bsm
@@ -134,7 +135,7 @@ class HestonUncorrBallRoma1994(HestonABC):
     def price(self, strike, spot, texp, cp=1):
 
         if not np.isclose(self.rho, 0.0):
-            print(f"Pricing ignores rho = {self.rho}.")
+            warnings.warn(f"Pricing ignores rho = {self.rho}.")
 
         avgvar, var = self.avgvar_mv(texp)
 

--- a/pyfeng/heston_mc.py
+++ b/pyfeng/heston_mc.py
@@ -1,4 +1,5 @@
 import abc
+import warnings
 import numpy as np
 import scipy.stats as spst
 import scipy.interpolate as spinterp
@@ -679,7 +680,7 @@ class HestonMcGlassermanKim2011(HestonMcABC):
         xx = np.insert(xx, 0, 0)
         cdf = np.insert(cdf, 0, 0)
         rv = spinterp.interp1d(cdf, xx, kind='linear')
-        print(f'Tabulated icdf for gamma shape={shape}')
+        warnings.warn(f"Tabulated icdf for gamma shape={shape}.")
         return rv
 
     def draw_eta(self, dt, var_0, var_t):

--- a/pyfeng/multiasset.py
+++ b/pyfeng/multiasset.py
@@ -38,7 +38,7 @@ class OptMaABC(opt.OptABC, abc.ABC):
 
         if self.n_asset == 1:
             if cor is not None:
-                print(f"Ignoring cor={cor} for a single asset")
+                warnings.warn(f"Ignoring cor={cor} for a single asset.")
             self.rho = None
             self.cor_m = np.array([[1.0]])
         elif np.isscalar(cor):
@@ -47,7 +47,8 @@ class OptMaABC(opt.OptABC, abc.ABC):
             ) * np.eye(self.n_asset)
             self.rho = cor
         else:
-            assert cor.shape == (self.n_asset, self.n_asset)
+            if cor.shape != (self.n_asset, self.n_asset):
+                raise ValueError(f"cor must have shape ({self.n_asset}, {self.n_asset}), got {cor.shape}.")
             self.cor_m = cor
             if self.n_asset == 2:
                 self.rho = cor[0, 1]
@@ -91,7 +92,8 @@ class BsmSpreadKirk(OptMaABC):
 
     def price(self, strike, spot, texp, cp=1):
         fwd, df, _ = self._fwd_factor(spot, texp)
-        assert fwd.shape[-1] == self.n_asset
+        if fwd.shape[-1] != self.n_asset:
+            raise ValueError(f"fwd last dimension {fwd.shape[-1]} does not match n_asset={self.n_asset}.")
 
         fwd1 = fwd[..., 0] - np.minimum(strike, 0)
         fwd2 = fwd[..., 1] + np.maximum(strike, 0)
@@ -122,7 +124,8 @@ class BsmSpreadBjerksund2014(OptMaABC):
 
     def price(self, strike, spot, texp, cp=1):
         fwd, df, _ = self._fwd_factor(spot, texp)
-        assert fwd.shape[-1] == self.n_asset
+        if fwd.shape[-1] != self.n_asset:
+            raise ValueError(f"fwd last dimension {fwd.shape[-1]} does not match n_asset={self.n_asset}.")
 
         fwd1 = fwd[..., 0]
         fwd2 = fwd[..., 1]
@@ -181,7 +184,8 @@ class NormBasket(OptMaABC):
         elif np.isscalar(weight):
             self.weight = np.ones(self.n_asset) * weight
         else:
-            assert len(weight) == self.n_asset
+            if len(weight) != self.n_asset:
+                raise ValueError(f"weight length {len(weight)} does not match n_asset={self.n_asset}.")
             self.weight = np.array(weight)
 
     @classmethod
@@ -202,7 +206,8 @@ class NormBasket(OptMaABC):
 
     def price(self, strike, spot, texp, cp=1):
         fwd, df, _ = self._fwd_factor(spot, texp)
-        assert fwd.shape[-1] == self.n_asset
+        if fwd.shape[-1] != self.n_asset:
+            raise ValueError(f"fwd last dimension {fwd.shape[-1]} does not match n_asset={self.n_asset}.")
 
         fwd_basket = fwd @ self.weight
         vol_basket = np.sqrt(self.weight @ self.cov_m @ self.weight)
@@ -234,7 +239,8 @@ class BsmBasketLevy1992(NormBasket):
 
     def price(self, strike, spot, texp, cp=1):
         fwd, df, _ = self._fwd_factor(spot, texp)
-        assert fwd.shape[-1] == self.n_asset
+        if fwd.shape[-1] != self.n_asset:
+            raise ValueError(f"fwd last dimension {fwd.shape[-1]} does not match n_asset={self.n_asset}.")
 
         fwd_basket = fwd * self.weight
         m1 = np.sum(fwd_basket, axis=-1)
@@ -266,7 +272,8 @@ class BsmBasketMilevsky1998(NormBasket):
 
     def price(self, strike, spot, texp, cp=1):
         fwd, df, _ = self._fwd_factor(spot, texp)
-        assert fwd.shape[-1] == self.n_asset
+        if fwd.shape[-1] != self.n_asset:
+            raise ValueError(f"fwd last dimension {fwd.shape[-1]} does not match n_asset={self.n_asset}.")
 
         fwd_basket = fwd * self.weight
         m1 = np.sum(fwd_basket, axis=-1)
@@ -306,7 +313,8 @@ class BsmMax2(OptMaABC):
     def price(self, strike, spot, texp, cp=1):
         sig = self.sigma
         fwd, df, _ = self._fwd_factor(spot, texp)
-        assert fwd.shape[-1] == self.n_asset
+        if fwd.shape[-1] != self.n_asset:
+            raise ValueError(f"fwd last dimension {fwd.shape[-1]} does not match n_asset={self.n_asset}.")
 
         sig_std = sig * np.sqrt(texp)
         spd_rho = np.sqrt(np.dot(sig, sig) - 2 * self.rho * sig[0] * sig[1])
@@ -350,7 +358,8 @@ class BsmMax2(OptMaABC):
                 spst.multivariate_normal.cdf(xx_ + sig_std, mu0, self.cor_m)
             )
 
-            assert term1 + term2 + term3 >= strike[k]
+            if term1 + term2 + term3 < strike[k]:
+                raise ValueError(f"Pricing error: lower bound violated at strike[{k}]={strike[k]}.")
             price[k] = term1 + term2 + term3 - strike[k]
 
             if cp[k] < 0:
@@ -385,7 +394,8 @@ class BsmBasket1Bm(opt.OptABC):
         elif np.isscalar(weight):
             self.weight = np.ones(self.n_asset) * weight
         else:
-            assert len(weight) == self.n_asset
+            if len(weight) != self.n_asset:
+                raise ValueError(f"weight length {len(weight)} does not match n_asset={self.n_asset}.")
             self.weight = np.array(weight)
         super().__init__(sigma, intr=intr, divr=divr, is_fwd=is_fwd)
 
@@ -401,7 +411,8 @@ class BsmBasket1Bm(opt.OptABC):
         strike: strike prices. scalar or (n_asset, )
         """
 
-        assert np.all(fac * std >= 0.0)
+        if not np.all(fac * std >= 0.0):
+            raise ValueError("fac * std must be non-negative for all assets.")
         log = np.min(fac) > 0  # Basket if log=True, spread if otherwise.
         scalar_output = np.isscalar(np.sum(fac * std, axis=-1) - strike)
         strike = np.atleast_1d(strike)
@@ -442,7 +453,7 @@ class BsmBasket1Bm(opt.OptABC):
             )
             x[ind] -= y / dy
             if len(y) == 0:
-                print(ind, y_vec, y)
+                warnings.warn(f"Implied vol solver: unexpected empty residual at ind={ind}.")
             y_err_max = np.amax(np.abs(y))
             if y_err_max < BsmBasket1Bm.IMPVOL_TOL:
                 break
@@ -457,7 +468,8 @@ class BsmBasket1Bm(opt.OptABC):
 
     def price(self, strike, spot, texp, cp=1):
         fwd, df, _ = self._fwd_factor(spot, texp)
-        assert fwd.shape[-1] == self.n_asset
+        if fwd.shape[-1] != self.n_asset:
+            raise ValueError(f"fwd last dimension {fwd.shape[-1]} does not match n_asset={self.n_asset}.")
 
         fwd_basket = fwd * self.weight
         sigma_std = self.sigma * np.sqrt(texp)
@@ -576,7 +588,8 @@ class BsmBasketJsu(NormBasket):
 
         """
         fwd, df, _ = self._fwd_factor(spot, texp)
-        assert fwd.shape[-1] == self.n_asset
+        if fwd.shape[-1] != self.n_asset:
+            raise ValueError(f"fwd last dimension {fwd.shape[-1]} does not match n_asset={self.n_asset}.")
 
         fwd_basket = fwd @ self.weight
 

--- a/pyfeng/multiasset_Ju2002.py
+++ b/pyfeng/multiasset_Ju2002.py
@@ -4,6 +4,7 @@ Created on Wed Apr 28 09:08:29 2021
 
 @author: Yuze, Lantian
 """
+import warnings
 from . import multiasset as ma
 from . import opt_abc as opt
 import numpy as np
@@ -330,10 +331,9 @@ class BsmContinuousAsianJu2002(opt.OptABC):
     def price(self, strike, spot, texp, cp=1):
 
         if np.isscalar(spot) == False:
-            print("spot should not be array")
-            return 0
+            raise ValueError("spot must be a scalar.")
         elif np.isscalar(self.divr) == False:
-            print("dividend should not be array")
+            raise ValueError("dividend (divr) must be a scalar.")
             return 0
         else:
             g = self.intr - self.divr

--- a/pyfeng/nsvh.py
+++ b/pyfeng/nsvh.py
@@ -1,4 +1,5 @@
 import abc
+import warnings
 import os
 import pandas as pd
 import numpy as np
@@ -29,7 +30,7 @@ class NsvhABC(smile.OptSmileABC, abc.ABC):
         """
         # Make sure beta = 0
         if beta is not None and not np.isclose(beta, 0.0):
-            print(f"Ignoring beta = {beta}...")
+            warnings.warn(f"Ignoring beta = {beta}.")
         self.lam = lam
         self.vov = vov
         self.rho = rho
@@ -268,7 +269,7 @@ class Nsvh1(NsvhABC):
             return (w + 1 - term1) * (w + 1 + 0.5 * term1)**2 - beta1
 
         assert f_beta1(w_min) >= 0
-        # print(w_min, f_beta1(w_min), w_max, f_beta1(w_max))
+
 
         # root finding for w = np.exp(S) = np.exp(vov^2 texp)
         w_root = spop.brentq(f_beta1, w_min, w_max)

--- a/pyfeng/ousv.py
+++ b/pyfeng/ousv.py
@@ -1,4 +1,5 @@
 import abc
+import warnings
 import numpy as np
 import scipy.integrate as scint
 from . import sv_abc as sv
@@ -273,7 +274,7 @@ class OusvUncorrBallRoma1994(OusvABC):
     def price(self, strike, spot, texp, cp=1):
 
         if not np.isclose(self.rho, 0.0):
-            print(f"Pricing ignores rho = {self.rho}.")
+            warnings.warn(f"Pricing ignores rho = {self.rho}.")
 
         avgvar, _ = self.avgvar_mv(texp, self.sigma)
 

--- a/pyfeng/sabr.py
+++ b/pyfeng/sabr.py
@@ -7,6 +7,7 @@ Created on Tue Oct 10
 
 import abc
 import copy
+import warnings
 import os
 import pandas as pd
 import numpy as np
@@ -518,7 +519,7 @@ class SabrNormVolApprox(SabrVolApproxABC):
         """
         # Make sure beta = 0
         if beta is not None and not np.isclose(beta, 0.0):
-            print(f"Ignoring beta = {beta}...")
+            warnings.warn(f"Ignoring beta = {beta}.")
         self.is_atmvol = is_atmvol
         super().__init__(sigma, vov, rho, beta=0, intr=intr, divr=divr, is_fwd=is_fwd)
 

--- a/pyfeng/sabr_int.py
+++ b/pyfeng/sabr_int.py
@@ -1,4 +1,5 @@
 import abc
+import warnings
 import numpy as np
 from . import sabr
 import scipy.special as spsp
@@ -58,7 +59,7 @@ class SabrMixtureABC(sabr.SabrABC, smile.MassZeroABC, abc.ABC):
         kk = strike / fwd
 
         fwd_ratio, vol_ratio, ww = self.cond_spot_sigma(texp, fwd)
-        # print(f'E(F) = {np.sum(fwd_ratio * ww)}')
+
 
         if self.correct_fwd:
             fwd_ratio /= np.sum(fwd_ratio*ww)
@@ -249,7 +250,7 @@ class SabrNormAnalytic(sabr.SabrABC):
         """
         # Make sure beta = 0
         if beta is not None and not np.isclose(beta, 0.0):
-            print(f"Ignoring beta = {beta}...")
+            warnings.warn(f"Ignoring beta = {beta}.")
         super().__init__(sigma, vov, rho, beta=0, intr=intr, divr=divr, is_fwd=is_fwd)
 
     def price(self, strike, spot, texp, cp=1):
@@ -322,7 +323,7 @@ class SabrNormEllipeInt(sabr.SabrABC):
         """
         # Make sure beta = 0
         if beta is not None and not np.isclose(beta, 0.0):
-            print(f"Ignoring beta = {beta}...")
+            warnings.warn(f"Ignoring beta = {beta}.")
         super().__init__(sigma, vov, rho, beta=0, intr=intr, divr=divr, is_fwd=is_fwd)
 
     @staticmethod

--- a/pyfeng/sabr_mc.py
+++ b/pyfeng/sabr_mc.py
@@ -1,5 +1,6 @@
 import math
 import abc
+import warnings
 import numpy as np
 import scipy.optimize as spop
 import scipy.stats as spst
@@ -376,7 +377,7 @@ class SabrMcCai2017Exact(SabrMcABC):
         uu = spst.norm.cdf(zz)
         ln_m, m2 = self.cond_avgvar_mv(vovn, np.log(sigma_t) / vovn)
         ln_sig = np.sqrt(np.log(m2 / ln_m ** 2))
-        print(sigma_t, '\n', ln_sig, '\n', uu)
+        # Debug: print(sigma_t, '\n', ln_sig, '\n', uu)
 
         def obj_func(z):
             x = ln_m * np.exp(ln_sig * (z - ln_sig / 2))

--- a/pyfeng/sv32_mc2.py
+++ b/pyfeng/sv32_mc2.py
@@ -71,7 +71,7 @@ class Sv32McABC(sv.SvABC, sv.CondMcBsmABC, abc.ABC):
         References:
             * https://functions.wolfram.com/Bessel-TypeFunctions/BesselI/20/ShowAll.html
         """
-        print(nu, zz)
+        # Debug: print(nu, zz)
         p0 = np.power(zz/2, nu) / spsp.gamma(nu + 1)
         #psi_1 = np.full_like(zz, spsp.polygamma(1, nu + 1), dtype=float)
         psi_1 = spsp.polygamma(1, nu + 1)

--- a/pyfeng/util.py
+++ b/pyfeng/util.py
@@ -71,7 +71,8 @@ class MathFuncs:
         Returns:
 
         """
-        assert np.all(x > -1.0)
+        if not np.all(x > -1.0):
+            raise ValueError("x must be greater than -1.0.")
 
         rv = np.ones_like(x)
         np.divide(np.log1p(x),  x, out=rv, where=(x != 0.0))
@@ -91,7 +92,8 @@ class MathFuncs:
 
         """
 
-        assert np.all(x > -1.0)
+        if not np.all(x > -1.0):
+            raise ValueError("x must be greater than -1.0.")
         a1p = 1.0 + a
         rv = np.ones_like(x + a)   # rv = 1 when x = 0
         np.divide(np.expm1(a1p * np.log1p(x)), a1p * x, out=rv, where=(x != 0.0) & (a1p != 0.0))
@@ -156,14 +158,16 @@ class DistHelperLnShift:
             None
         """
 
-        assert len(mvs) >= 2
+        if len(mvs) < 2:
+            raise ValueError("mvs must have at least 2 elements (mean and variance).")
 
         self.mu = mvs[0]
 
         if len(mvs) == 2 or lam is not None:  # use (m, v) only
             if lam is None:
                 # if lam is None, self.lam should be specified
-                assert self.lam is not None
+                if self.lam is None:
+                    raise ValueError("lam must be specified when mvs has only 2 elements.")
             else:
                 # if lam is specified, store it to self.lam
                 self.lam = lam
@@ -171,7 +175,8 @@ class DistHelperLnShift:
             self._ww = mvs[1] / self.lam**2
             self.sig = np.sqrt(np.log1p(self._ww))
         else:
-            assert len(mvs) > 2
+            if len(mvs) <= 2:
+                raise ValueError("mvs must have more than 2 elements when lam is not specified.")
             s = mvs[2]
             sqrt_w = 2*np.sinh(np.arccosh(1 + 0.5*s**2)/6)
             self.lam = np.sqrt(mvs[1]) / sqrt_w
@@ -182,7 +187,8 @@ class DistHelperLnShift:
             n = 2 if len(mvs) == 2 or lam is not None else 3
             mvsk2 = self.mvsk()
             for (i,v) in enumerate(mvs[:n]):
-                assert np.isclose(v, mvsk2[i])
+                if not np.isclose(v, mvsk2[i]):
+                    raise ValueError(f"Moment validation failed at index {i}: expected {v}, got {mvsk2[i]}.")
 
     def quad(self, n_quad):
         """

--- a/tests/test_bsm_norm.py
+++ b/tests/test_bsm_norm.py
@@ -75,8 +75,8 @@ class TestBsmMethods(unittest.TestCase):
             delta2 = m_bsm.delta_numeric(strike=strike, spot=spot, texp=texp, cp=cp)
             self.assertAlmostEqual(delta1, delta2, delta=1e-4)
 
-            gamma1 = m_bsm.delta(strike=strike, spot=spot, texp=texp, cp=cp)
-            gamma2 = m_bsm.delta_numeric(strike=strike, spot=spot, texp=texp, cp=cp)
+            gamma1 = m_bsm.gamma(strike=strike, spot=spot, texp=texp, cp=cp)
+            gamma2 = m_bsm.gamma_numeric(strike=strike, spot=spot, texp=texp, cp=cp)
             self.assertAlmostEqual(gamma1, gamma2, delta=1e-4)
 
             vega1 = m_bsm.vega(strike=strike, spot=spot, texp=texp, cp=cp)


### PR DESCRIPTION
print() → warnings.warn() — 13 live prints replaced across heston.py, garch.py, ousv.py, nsvh.py, sabr.py, sabr_int.py, multiasset.py, heston_mc.py, assetalloc.py, multiasset_Ju2002.py, sv32_mc2.py; 2 stale commented prints removed assert → raise ValueError — 12 assertions replaced across multiasset.py, assetalloc.py, util.py Gamma test bug — tests/test_bsm_norm.py lines 78–80 now correctly call gamma()/gamma_numeric()