### PR TITLE
ADI Finite Difference

### DIFF
--- a/pyfeng/__init__.py
+++ b/pyfeng/__init__.py
@@ -27,7 +27,7 @@ from .nsvh import Nsvh1, NsvhMc, NsvhGaussQuad
 from .garch import GarchMcTimeDisc, GarchUncorrBaroneAdesi2004
 
 from .heston import CirModel, HestonUncorrBallRoma1994
-from .sv_fin_diff import SabrFinDiff, HestonFinDiff
+from .sv_fin_diff import SabrFinDiff, HestonFinDiff, HestonCevFinDiff
 from .heston_mc import (
     HestonMcAndersen2008, HestonMcGlassermanKim2011, HestonMcTseWan2013,
     HestonMcChoiKwok2023PoisGe, HestonMcChoiKwok2023PoisTd

--- a/pyfeng/__init__.py
+++ b/pyfeng/__init__.py
@@ -27,6 +27,7 @@ from .nsvh import Nsvh1, NsvhMc, NsvhGaussQuad
 from .garch import GarchMcTimeDisc, GarchUncorrBaroneAdesi2004
 
 from .heston import CirModel, HestonUncorrBallRoma1994
+from .sv_fin_diff import SabrFinDiff, HestonFinDiff
 from .heston_mc import (
     HestonMcAndersen2008, HestonMcGlassermanKim2011, HestonMcTseWan2013,
     HestonMcChoiKwok2023PoisGe, HestonMcChoiKwok2023PoisTd

--- a/pyfeng/heston.py
+++ b/pyfeng/heston.py
@@ -4,7 +4,7 @@ import scipy.special as spsp
 from .opt_abc import OptABC
 from . import bsm
 from .util import MathFuncs
-from .params import HestonParams
+from .params import HestonParams, HestonCevParams
 
 
 class CirModel:
@@ -404,6 +404,21 @@ class HestonABC(HestonParams, OptABC):
         var = texp * mu_i + (texp**2 / 4) * var_i - self.rho * texp / self.vov * cov_yi
 
         return mean, var
+
+
+class HestonCevABC(HestonCevParams, OptABC):
+    """
+    Abstract base class for CEV-Heston models.
+
+    Provides the ``cir`` property for the variance sub-process (identical to
+    ``HestonABC.cir``; the CEV exponent ``beta`` does not affect the variance
+    dynamics).
+    """
+
+    @property
+    def cir(self):
+        """CirModel instance for the variance process (ξ = vov, κ = mr, θ = theta)."""
+        return CirModel(sigma=self.vov, mr=self.mr, theta=self.theta)
 
 
 class HestonUncorrBallRoma1994(HestonABC):

--- a/pyfeng/params.py
+++ b/pyfeng/params.py
@@ -298,6 +298,32 @@ class HestonParams(SvParams):
 
 
 @dataclass
+class HestonCevParams(HestonParams):
+    """
+    Parameters for the CEV-Heston stochastic-volatility model.
+
+    Extends the standard Heston model with a CEV elasticity parameter ``beta``::
+
+        dS_t = sqrt(v_t) · S_t^beta · dW_S + drift
+        dv_t = kappa·(theta − v_t) dt + vov·sqrt(v_t) dW_v,  corr(dW_S, dW_v) = rho
+
+    With ``beta = 1`` the model reduces to standard Heston.  ``beta < 1`` adds a
+    leverage effect (local volatility decreases with spot).
+
+    Field order in ``__init__``:
+    ``(sigma, beta=1.0, vov=0.01, rho=0.0, mr=0.01, theta=None,
+    *, intr=0.0, divr=0.0, is_fwd=False)``
+    """
+    model_type: ClassVar[str] = "HestonCev"
+    beta: float = 1.0
+
+    def __post_init__(self):
+        super().__post_init__()   # validates Heston constraints + sets theta
+        if not (self.beta > 0):
+            raise ValueError(f"beta must be > 0 for CEV-Heston, got {self.beta}")
+
+
+@dataclass
 class GarchParams(SvParams):
     """Parameters for the GARCH diffusion model."""
     model_type: ClassVar[str] = "GarchDiff"

--- a/pyfeng/sv_fin_diff.py
+++ b/pyfeng/sv_fin_diff.py
@@ -18,9 +18,9 @@ One Douglas step τₙ → τₙ₊₁ (θ = ½ gives Crank–Nicolson-like accu
     (I − θ dt F₁) Y₁ = Y₀ − θ dt F₁ Vⁿ              (S-implicit corrector)
     (I − θ dt F₂) Vⁿ⁺¹ = Y₁ − θ dt F₂ Vⁿ            (v-implicit corrector)
 
-To use for a new SV model, subclass ``SvFinDiffMixin`` and implement
+To use for a new SV model, subclass ``SvFinDiffMixinABC`` and implement
 four abstract methods: ``_get_v0``, ``_grid_bounds``, ``_coefficients``,
-``_apply_bc``.
+``_apply_bdd_cond``.
 
 References:
     von Sydow et al. (2019) BENCHOP-SLV, Int. J. Comput. Math.
@@ -110,44 +110,41 @@ def _standard_bc(V, kk, X, cp):
 
 
 # ─────────────────────────────────────────────────────────────────────────────
-# Generic ADI mixin
+# Generic ADI mixin ABC
 # ─────────────────────────────────────────────────────────────────────────────
 
-class SvFinDiffMixin(abc.ABC):
+class SvFinDiffMixinABC(abc.ABC):
     """
     Generic Douglas-scheme 2D ADI mixin for stochastic-volatility models.
 
     Subclass and implement four abstract methods to plug in any model::
 
-        class MyModelFinDiff(SvFinDiffMixin, MyModelABC):
+        class MyModelFinDiff(SvFinDiffMixinABC, MyModelABC):
             def _get_v0(self, fwd, texp):         return ...
             def _grid_bounds(self, v0, kk, texp): return X_min, X_max, v_max
             def _coefficients(self, X, v):        return aS, bS, aV, bV, gamma
-            def _apply_bc(self, V, kk, X, cp):    return _standard_bc(V, kk, X, cp)
+            def _apply_bdd_cond(self, V, kk, X, cp):    return _standard_bc(V, kk, X, cp)
 
     The engine works in normalized forward space (X = F/F₀, so X₀ = 1, r=q=0).
     ``price()`` handles forward/discount scaling externally.
     """
 
     # Default numerical parameters — override via set_num_params()
-    n_asset:   int   = 80
-    n_vol:     int   = 40
-    n_time:    int   = 80
+    # n_grid = (N_time, M_price, L_vol); matches BENCHOP-SLV convention M = 2L, N ≈ L
+    n_grid:    tuple = (80, 80, 40)
     adi_theta: float = 0.5
 
-    def set_num_params(self, n_asset=80, n_vol=40, n_time=80, adi_theta=0.5):
+    def set_num_params(self, n_grid=(80, 80, 40), adi_theta=0.5):
         """
         Configure the ADI grid (consistent with ``set_num_params`` in *_mc.py).
 
         Args:
-            n_asset:   asset price grid intervals (M)
-            n_vol:     vol/variance grid intervals (L)
-            n_time:    time steps (N)
+            n_grid:    (N_time, M_price, L_vol) — number of time steps and
+                       spatial grid intervals in the price and vol directions.
+                       BENCHOP-SLV convention: M = 2L, N ≈ L.
             adi_theta: Douglas weight; 0.5 → Crank–Nicolson accuracy
         """
-        self.n_asset   = int(n_asset)
-        self.n_vol     = int(n_vol)
-        self.n_time    = int(n_time)
+        self.n_grid    = tuple(int(x) for x in n_grid)
         self.adi_theta = float(adi_theta)
 
     # ── Abstract interface ────────────────────────────────────────────────────
@@ -197,7 +194,7 @@ class SvFinDiffMixin(abc.ABC):
         """
 
     @abc.abstractmethod
-    def _apply_bc(self, V, kk, X, cp):
+    def _apply_bdd_cond(self, V, kk, X, cp):
         """
         Boundary conditions in normalized space.
 
@@ -246,7 +243,7 @@ class SvFinDiffMixin(abc.ABC):
 
     def _solve_one(self, kk, v0, texp, cp):
         """Full Douglas ADI solve in normalized space. Returns price / F₀."""
-        M, L, N = self.n_asset, self.n_vol, self.n_time
+        N, M, L = self.n_grid
 
         X_min, X_max, v_max = self._grid_bounds(v0, kk, texp)
         X  = np.linspace(X_min, X_max, M + 1)
@@ -257,9 +254,8 @@ class SvFinDiffMixin(abc.ABC):
 
         # Terminal condition (τ = 0): intrinsic payoff broadcast over v-axis
         V = np.maximum(cp * (X[:, None] - kk), 0.0) * np.ones((M + 1, L + 1))
-        # v = 0 initial condition is always intrinsic (τ = 0 payoff)
         V[:, 0] = np.maximum(cp * (X - kk), 0.0)
-        V = self._apply_bc(V, kk, X, cp)
+        V = self._apply_bdd_cond(V, kk, X, cp)
 
         for _ in range(N):
             V = self._pre_step(V, X, v, dX, dv, dt, kk, cp)
@@ -278,7 +274,7 @@ class SvFinDiffMixin(abc.ABC):
         F2V = self._F2(V, aV, bV, dv)
 
         Y0 = V + dt * (F0V + F1V + F2V)
-        Y0 = self._apply_bc(Y0, kk, X, cp)
+        Y0 = self._apply_bdd_cond(Y0, kk, X, cp)
 
         Y1  = self._solve_S_implicit(Y0 - adt * F1V, adt, aS, bS, dX, X, kk, cp)
         Vn  = self._solve_v_implicit(Y1 - adt * F2V, adt, aV, bV, dv, X, kk, cp)
@@ -301,7 +297,7 @@ class SvFinDiffMixin(abc.ABC):
     def _F1(V, aS, bS, dX):
         """Asset-direction differential operator."""
         out = np.zeros_like(V)
-        a = aS[1:-1, :] / dX**2      # (M-1, L+1) or broadcasts
+        a = aS[1:-1, :] / dX**2
         b = bS[1:-1, :] / (2.0 * dX)
         out[1:-1, :] = (
             a * (V[2:, :] - 2.0 * V[1:-1, :] + V[:-2, :])
@@ -313,7 +309,6 @@ class SvFinDiffMixin(abc.ABC):
     def _F2(V, aV, bV, dv):
         """Vol-direction differential operator."""
         out = np.zeros_like(V)
-        # aV, bV are (1, L+1) or (M+1, L+1); slice interior v-axis
         c = aV[..., 1:-1] / dv**2
         d = bV[..., 1:-1] / (2.0 * dv)
         out[:, 1:-1] = (
@@ -326,61 +321,65 @@ class SvFinDiffMixin(abc.ABC):
 
     def _solve_S_implicit(self, rhs, adt, aS, bS, dX, X, kk, cp):
         """Solve (I − adt·F₁)Y = rhs for interior S-points, all interior v."""
-        M, L = self.n_asset, self.n_vol
-        Y = self._apply_bc(rhs.copy(), kk, X, cp)
+        _, M, L = self.n_grid
+        Y = self._apply_bdd_cond(rhs.copy(), kk, X, cp)
 
-        # Coefficient arrays for interior (i=1..M-1, j=1..L-1)
-        a = aS[1:M, 1:L] / dX**2      # (M-1, L-1)
-        b = bS[1:M, 1:L] / (2.0 * dX) # (M-1, L-1)
+        a = aS[1:M, 1:L] / dX**2
+        b = bS[1:M, 1:L] / (2.0 * dX)
 
         sub = -adt * (a - b)
         mid =  1.0 + adt * 2.0 * a
         sup = -adt * (a + b)
 
         rhs_int = rhs[1:M, 1:L].copy()
-        # Fold known boundary S-values into right-hand side
         rhs_int[0,  :] -= sub[0,  :] * Y[0,  1:L]
         rhs_int[-1, :] -= sup[-1, :] * Y[M,  1:L]
 
         Y[1:M, 1:L] = _thomas_batch(sub, mid, sup, rhs_int)
-        return self._apply_bc(Y, kk, X, cp)
+        return self._apply_bdd_cond(Y, kk, X, cp)
 
     def _solve_v_implicit(self, rhs, adt, aV, bV, dv, X, kk, cp):
         """Solve (I − adt·F₂)Y = rhs for interior v-points, all S."""
-        M, L = self.n_asset, self.n_vol
-        Y = self._apply_bc(rhs.copy(), kk, X, cp)
+        _, M, L = self.n_grid
+        Y = self._apply_bdd_cond(rhs.copy(), kk, X, cp)
 
-        # Extract 1-D interior v-coefficients  (aV, bV may be (1,L+1))
         av = np.asarray(aV).ravel() if aV.shape[0] == 1 else aV[0]
         bv = np.asarray(bV).ravel() if bV.shape[0] == 1 else bV[0]
-        c = av[1:L] / dv**2    # (L-1,)
+        c = av[1:L] / dv**2
         d = bv[1:L] / (2.0 * dv)
 
         sub = -adt * (c - d)
         mid =  1.0 + adt * 2.0 * c
         sup = -adt * (c + d)
 
-        # Neumann BC at v_max: V[:, L] = V[:, L-1]  →  fold last sup into diagonal
+        # Neumann BC at v_max: fold last sup into diagonal
         mid_eff = mid.copy()
         mid_eff[-1] += sup[-1]
 
-        # Transpose so v-axis is first (Thomas iterates along v)
         rhs_int = rhs[:, 1:L].T.copy()       # (L-1, M+1)
         rhs_int[0, :] -= sub[0] * Y[:, 0]    # Dirichlet at v = 0
 
         sol = _thomas_batch(sub, mid_eff, sup, rhs_int)  # (L-1, M+1)
         Y[:, 1:L] = sol.T
         Y[:, L]   = Y[:, L - 1]              # enforce Neumann mirror
-        return self._apply_bc(Y, kk, X, cp)
+        return self._apply_bdd_cond(Y, kk, X, cp)
 
 
 # ─────────────────────────────────────────────────────────────────────────────
-# SABR mixin
+# Imports — deferred to avoid circular references
 # ─────────────────────────────────────────────────────────────────────────────
 
-class SabrFinDiffMixin(SvFinDiffMixin):
+from .sabr import SabrABC                    # noqa: E402
+from .heston import HestonABC, HestonCevABC  # noqa: E402
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# SABR concrete pricer
+# ─────────────────────────────────────────────────────────────────────────────
+
+class SabrFinDiff(SvFinDiffMixinABC, SabrABC):
     """
-    SABR PDE coefficients for the generic Douglas ADI engine.
+    European SABR option pricing via 2D Douglas ADI finite differences.
 
     PyFENG parameter mapping:
         ``sigma`` → σ₀ (initial vol level)
@@ -416,17 +415,17 @@ class SabrFinDiffMixin(SvFinDiffMixin):
         gamma = self.rho * self.vov * vr**2 * Xc**self.beta
         return aS, bS, aV, bV, gamma
 
-    def _apply_bc(self, V, kk, X, cp):
+    def _apply_bdd_cond(self, V, kk, X, cp):
         return _standard_bc(V, kk, X, cp)
 
 
 # ─────────────────────────────────────────────────────────────────────────────
-# Heston mixin
+# Heston concrete pricer
 # ─────────────────────────────────────────────────────────────────────────────
 
-class HestonFinDiffMixin(SvFinDiffMixin):
+class HestonFinDiff(SvFinDiffMixinABC, HestonABC):
     """
-    Heston PDE coefficients for the generic Douglas ADI engine.
+    European Heston option pricing via 2D Douglas ADI finite differences.
 
     PyFENG parameter mapping:
         ``sigma`` → v₀ (initial variance)
@@ -435,14 +434,11 @@ class HestonFinDiffMixin(SvFinDiffMixin):
         ``theta`` → θ  (long-run variance)
         ``rho``   → ρ  (correlation)
 
-    The variance process is scale-free so no forward normalization is needed.
-
     Boundary at v = 0:
         When the Feller condition 2κθ ≥ ξ² is violated the variance can reach
         zero and the PDE degenerates to  ∂V/∂τ = κθ ∂V/∂v.  This is integrated
         explicitly via ``_pre_step`` at every time step rather than freezing the
-        option value at the intrinsic payoff (which would under-price options
-        with positive expected variance recovery).
+        option value at the intrinsic payoff.
     """
 
     def _get_v0(self, fwd, texp):
@@ -468,7 +464,7 @@ class HestonFinDiffMixin(SvFinDiffMixin):
         gamma = self.rho * self.vov * vr * Xc
         return aS, bS, aV, bV, gamma
 
-    def _apply_bc(self, V, kk, X, cp):
+    def _apply_bdd_cond(self, V, kk, X, cp):
         """
         Heston boundary conditions.
 
@@ -497,58 +493,35 @@ class HestonFinDiffMixin(SvFinDiffMixin):
         S-direction and v_max boundary conditions.
         """
         V[:, 0] += dt * self.mr * self.theta * (V[:, 1] - V[:, 0]) / dv
-        return self._apply_bc(V, kk, X, cp)
+        return self._apply_bdd_cond(V, kk, X, cp)
 
 
 # ─────────────────────────────────────────────────────────────────────────────
-# Concrete classes
+# CEV-Heston concrete pricer
 # ─────────────────────────────────────────────────────────────────────────────
 
-from .sabr import SabrABC                   # noqa: E402
-from .heston import HestonABC, HestonCevABC  # noqa: E402
-
-
-class SabrFinDiff(SabrFinDiffMixin, SabrABC):
-    """European SABR option pricing via 2D Douglas ADI finite differences."""
-
-
-class HestonFinDiff(HestonFinDiffMixin, HestonABC):
-    """European Heston option pricing via 2D Douglas ADI finite differences."""
-
-
-# ─────────────────────────────────────────────────────────────────────────────
-# CEV-Heston mixin and concrete class
-# ─────────────────────────────────────────────────────────────────────────────
-
-class HestonCevFinDiffMixin(HestonFinDiffMixin):
+class HestonCevFinDiff(HestonCevABC, HestonFinDiff):
     """
-    CEV-Heston PDE coefficients for the generic Douglas ADI engine.
+    European CEV-Heston option pricing via 2D Douglas ADI finite differences.
 
-    Generalises the standard Heston asset SDE with a CEV elasticity ``beta``::
+    Generalises ``HestonFinDiff`` with a CEV elasticity ``beta``::
 
-        dS = sqrt(v) · S^beta · dW_S
+        dS = sqrt(v) · S^beta · dW_S,   beta = 1 → standard Heston
 
-    With ``beta = 1`` this reduces to standard ``HestonFinDiffMixin``.
+    Inherits grid bounds, boundary conditions, and the degenerate-PDE
+    ``_pre_step`` from ``HestonFinDiff``; overrides only ``_coefficients``.
 
-    Only the asset-direction coefficients differ from Heston:
-
-    * ``aS    = ½ · v · X^(2β)``   (Heston: ½·v·X²)
-    * ``gamma = ρ · ξ · v · X^β``  (Heston: ρ·ξ·v·X)
-
-    The variance-direction coefficients (``aV``, ``bV``) and all boundary
-    conditions are inherited unchanged from ``HestonFinDiffMixin``.
+    PDE coefficients that differ from standard Heston:
+        aS    = ½ · v · X^(2β)   (Heston: ½·v·X²)
+        gamma = ρ · ξ · v · X^β  (Heston: ρ·ξ·v·X)
     """
 
     def _coefficients(self, X, v):
         Xc = X[:, None]   # (M+1, 1)
         vr = v[None, :]   # (1,  L+1)
         aS    = 0.5 * vr * Xc**(2.0 * self.beta)
-        bS    = np.zeros_like(aS)                  # r = q = 0 (normalized)
+        bS    = np.zeros_like(aS)
         aV    = 0.5 * self.vov**2 * vr             # unchanged from Heston
         bV    = self.mr * (self.theta - vr)        # unchanged from Heston
         gamma = self.rho * self.vov * vr * Xc**self.beta
         return aS, bS, aV, bV, gamma
-
-
-class HestonCevFinDiff(HestonCevFinDiffMixin, HestonCevABC):
-    """European CEV-Heston option pricing via 2D Douglas ADI finite differences."""

--- a/pyfeng/sv_fin_diff.py
+++ b/pyfeng/sv_fin_diff.py
@@ -18,13 +18,19 @@ One Douglas step τₙ → τₙ₊₁ (θ = ½ gives Crank–Nicolson-like accu
     (I − θ dt F₁) Y₁ = Y₀ − θ dt F₁ Vⁿ              (S-implicit corrector)
     (I − θ dt F₂) Vⁿ⁺¹ = Y₁ − θ dt F₂ Vⁿ            (v-implicit corrector)
 
-To use for a new SV model, subclass ``SvFinDiffMixinABC`` and implement
+To use for a new SV model, subclass ``SvFinDiffABC`` and implement
 four abstract methods: ``_get_v0``, ``_grid_bounds``, ``_coefficients``,
 ``_apply_bdd_cond``.
 
 References:
     von Sydow et al. (2019) BENCHOP-SLV, Int. J. Comput. Math.
     K. in 't Hout & S. Foulon (2010), ADI FD schemes for Heston.
+
+Credits:
+    Adapted from the MATH5030 Group 16 project (``mafn-finite-difference``),
+    which provided the original Douglas ADI implementation for SABR and
+    extended Heston models.
+    Repository: https://github.com/py2025/finite-difference
 """
 
 import abc
@@ -113,13 +119,13 @@ def _standard_bc(V, kk, X, cp):
 # Generic ADI mixin ABC
 # ─────────────────────────────────────────────────────────────────────────────
 
-class SvFinDiffMixinABC(abc.ABC):
+class SvFinDiffABC(abc.ABC):
     """
     Generic Douglas-scheme 2D ADI mixin for stochastic-volatility models.
 
     Subclass and implement four abstract methods to plug in any model::
 
-        class MyModelFinDiff(SvFinDiffMixinABC, MyModelABC):
+        class MyModelFinDiff(SvFinDiffABC, MyModelABC):
             def _get_v0(self, fwd, texp):         return ...
             def _grid_bounds(self, v0, kk, texp): return X_min, X_max, v_max
             def _coefficients(self, X, v):        return aS, bS, aV, bV, gamma
@@ -377,7 +383,7 @@ from .heston import HestonABC, HestonCevABC  # noqa: E402
 # SABR concrete pricer
 # ─────────────────────────────────────────────────────────────────────────────
 
-class SabrFinDiff(SvFinDiffMixinABC, SabrABC):
+class SabrFinDiff(SvFinDiffABC, SabrABC):
     """
     European SABR option pricing via 2D Douglas ADI finite differences.
 
@@ -423,7 +429,7 @@ class SabrFinDiff(SvFinDiffMixinABC, SabrABC):
 # Heston concrete pricer
 # ─────────────────────────────────────────────────────────────────────────────
 
-class HestonFinDiff(SvFinDiffMixinABC, HestonABC):
+class HestonFinDiff(SvFinDiffABC, HestonABC):
     """
     European Heston option pricing via 2D Douglas ADI finite differences.
 
@@ -486,13 +492,20 @@ class HestonFinDiff(SvFinDiffMixinABC, HestonABC):
 
     def _pre_step(self, V, X, v, dX, dv, dt, kk, cp):
         """
-        Explicit degenerate PDE step at v = 0.
+        v = 0 boundary update before each Douglas step.
 
-        Integrates  ∂V/∂τ = κθ (V[:,1] − V[:,0]) / dv  for one time step
-        using forward Euler before the Douglas ADI sweep, then re-applies the
-        S-direction and v_max boundary conditions.
+        **Feller violated** (2κθ < ξ²): v = 0 is attainable.  The PDE
+        degenerates to  ∂V/∂τ = κθ ∂V/∂v, integrated by forward Euler.
+        CFL stability requires  κθ · dt/dv ≤ 1.
+
+        **Feller satisfied** (2κθ ≥ ξ²): v = 0 is unreachable.  The v = 0
+        column is pinned to the absorbing Dirichlet value (intrinsic payoff),
+        which is both physically correct and unconditionally stable.
         """
-        V[:, 0] += dt * self.mr * self.theta * (V[:, 1] - V[:, 0]) / dv
+        if 2.0 * self.mr * self.theta < self.vov**2:   # Feller violated
+            V[:, 0] += dt * self.mr * self.theta * (V[:, 1] - V[:, 0]) / dv
+        else:                                           # Feller satisfied
+            V[:, 0] = np.maximum(cp * (X - kk), 0.0)
         return self._apply_bdd_cond(V, kk, X, cp)
 
 

--- a/pyfeng/sv_fin_diff.py
+++ b/pyfeng/sv_fin_diff.py
@@ -513,8 +513,10 @@ from .heston import HestonABC  # noqa: E402
 class SabrFinDiff(SabrFinDiffMixin, SabrABC):
     """European SABR option pricing via 2D Douglas ADI finite differences."""
     model_type = 'SabrFinDiff'
+    _benchmark_file = 'sabr_benchmark.xlsx'
 
 
 class HestonFinDiff(HestonFinDiffMixin, HestonABC):
     """European Heston option pricing via 2D Douglas ADI finite differences."""
     model_type = 'HestonFinDiff'
+    _benchmark_file = 'heston_benchmark.xlsx'

--- a/pyfeng/sv_fin_diff.py
+++ b/pyfeng/sv_fin_diff.py
@@ -8,9 +8,9 @@ The 2D PDE for V(X, v, τ), τ = T − t has the form::
 
     dV/dτ = (F₀ + F₁ + F₂) V
 
-    F₀: γ(X,v,τ)  · ∂²V/∂X∂v              (explicit; mixed derivative)
-    F₁: aS(X,v,τ) · ∂²V/∂X² + bS(X,v,τ) · ∂V/∂X   (S-direction implicit)
-    F₂: aV(X,v,τ) · ∂²V/∂v² + bV(X,v,τ) · ∂V/∂v   (v-direction implicit)
+    F₀: γ(X,v)  · ∂²V/∂X∂v              (explicit; mixed derivative)
+    F₁: aS(X,v) · ∂²V/∂X² + bS(X,v) · ∂V/∂X   (S-direction implicit)
+    F₂: aV(X,v) · ∂²V/∂v² + bV(X,v) · ∂V/∂v   (v-direction implicit)
 
 One Douglas step τₙ → τₙ₊₁ (θ = ½ gives Crank–Nicolson-like accuracy)::
 
@@ -120,9 +120,9 @@ class SvFinDiffMixin(abc.ABC):
     Subclass and implement four abstract methods to plug in any model::
 
         class MyModelFinDiff(SvFinDiffMixin, MyModelABC):
-            def _get_v0(self, fwd, texp):   return ...
+            def _get_v0(self, fwd, texp):         return ...
             def _grid_bounds(self, v0, kk, texp): return X_min, X_max, v_max
-            def _coefficients(self, X, v, tau):   return aS, bS, aV, bV, gamma
+            def _coefficients(self, X, v):        return aS, bS, aV, bV, gamma
             def _apply_bc(self, V, kk, X, cp):    return _standard_bc(V, kk, X, cp)
 
     The engine works in normalized forward space (X = F/F₀, so X₀ = 1, r=q=0).
@@ -176,14 +176,15 @@ class SvFinDiffMixin(abc.ABC):
         """
 
     @abc.abstractmethod
-    def _coefficients(self, X, v, tau):
+    def _coefficients(self, X, v):
         """
         PDE operator coefficients on the full (M+1) × (L+1) grid.
 
+        Parameters are assumed constant (time-independent).
+
         Args:
-            X:   asset grid, shape (M+1,)
-            v:   vol/variance grid, shape (L+1,)
-            tau: time-to-maturity; pass to callable parameters if time-dependent
+            X: asset grid, shape (M+1,)
+            v: vol/variance grid, shape (L+1,)
 
         Returns:
             aS, bS, aV, bV, gamma — each broadcastable to (M+1, L+1).
@@ -233,7 +234,7 @@ class SvFinDiffMixin(abc.ABC):
 
     # ── Core ADI solver ───────────────────────────────────────────────────────
 
-    def _pre_step(self, V, X, v, dX, dv, dt, tau, kk, cp):
+    def _pre_step(self, V, X, v, dX, dv, dt, kk, cp):
         """
         Hook called before each Douglas step.
 
@@ -260,20 +261,17 @@ class SvFinDiffMixin(abc.ABC):
         V[:, 0] = np.maximum(cp * (X - kk), 0.0)
         V = self._apply_bc(V, kk, X, cp)
 
-        for n in range(N):
-            tau_old = n * dt
-            tau_new = (n + 1) * dt
-            V = self._pre_step(V, X, v, dX, dv, dt, tau_old, kk, cp)
-            V = self._step(V, X, v, dX, dv, dt, tau_old, tau_new, kk, cp)
+        for _ in range(N):
+            V = self._pre_step(V, X, v, dX, dv, dt, kk, cp)
+            V = self._step(V, X, v, dX, dv, dt, kk, cp)
 
         return _bilinear(V, X, v, 1.0, v0)
 
-    def _step(self, V, X, v, dX, dv, dt, tau_old, tau_new, kk, cp):
-        """One Douglas step: advance V from τ_old to τ_new."""
-        adt     = self.adi_theta * dt
-        tau_mid = 0.5 * (tau_old + tau_new)
+    def _step(self, V, X, v, dX, dv, dt, kk, cp):
+        """One Douglas step: advance V by one time increment dt."""
+        adt = self.adi_theta * dt
 
-        aS, bS, aV, bV, gamma = self._coefficients(X, v, tau_mid)
+        aS, bS, aV, bV, gamma = self._coefficients(X, v)
 
         F0V = self._F0(V, gamma, dX, dv)
         F1V = self._F1(V, aS, bS, dX)
@@ -408,7 +406,7 @@ class SabrFinDiffMixin(SvFinDiffMixin):
         X_min = 0.0 if self.beta > 0.0 else min(0.0, 1.0 - 5.0 * v0 * sq)
         return float(X_min), float(X_max), float(v_max)
 
-    def _coefficients(self, X, v, tau):
+    def _coefficients(self, X, v):
         Xc = X[:, None]   # (M+1, 1)
         vr = v[None, :]   # (1,  L+1)
         aS    = 0.5 * vr**2 * Xc**(2.0 * self.beta)
@@ -460,7 +458,7 @@ class HestonFinDiffMixin(SvFinDiffMixin):
         v_max = max(5.0 * float(v0), self.theta + 5.0 * cir_std)
         return 0.0, float(X_max), float(v_max)
 
-    def _coefficients(self, X, v, tau):
+    def _coefficients(self, X, v):
         Xc = X[:, None]   # (M+1, 1)
         vr = v[None, :]   # (1,  L+1)
         aS    = 0.5 * vr * Xc**2
@@ -490,7 +488,7 @@ class HestonFinDiffMixin(SvFinDiffMixin):
         V[:, -1] = V[:, -2]   # Neumann at v_max
         return V
 
-    def _pre_step(self, V, X, v, dX, dv, dt, tau, kk, cp):
+    def _pre_step(self, V, X, v, dX, dv, dt, kk, cp):
         """
         Explicit degenerate PDE step at v = 0.
 

--- a/pyfeng/sv_fin_diff.py
+++ b/pyfeng/sv_fin_diff.py
@@ -512,11 +512,9 @@ from .heston import HestonABC  # noqa: E402
 
 class SabrFinDiff(SabrFinDiffMixin, SabrABC):
     """European SABR option pricing via 2D Douglas ADI finite differences."""
-    model_type = 'SabrFinDiff'
     _benchmark_file = 'sabr_benchmark.xlsx'
 
 
 class HestonFinDiff(HestonFinDiffMixin, HestonABC):
     """European Heston option pricing via 2D Douglas ADI finite differences."""
-    model_type = 'HestonFinDiff'
     _benchmark_file = 'heston_benchmark.xlsx'

--- a/pyfeng/sv_fin_diff.py
+++ b/pyfeng/sv_fin_diff.py
@@ -504,8 +504,8 @@ class HestonFinDiffMixin(SvFinDiffMixin):
 # Concrete classes
 # ─────────────────────────────────────────────────────────────────────────────
 
-from .sabr import SabrABC      # noqa: E402
-from .heston import HestonABC  # noqa: E402
+from .sabr import SabrABC                   # noqa: E402
+from .heston import HestonABC, HestonCevABC  # noqa: E402
 
 
 class SabrFinDiff(SabrFinDiffMixin, SabrABC):
@@ -514,3 +514,41 @@ class SabrFinDiff(SabrFinDiffMixin, SabrABC):
 
 class HestonFinDiff(HestonFinDiffMixin, HestonABC):
     """European Heston option pricing via 2D Douglas ADI finite differences."""
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# CEV-Heston mixin and concrete class
+# ─────────────────────────────────────────────────────────────────────────────
+
+class HestonCevFinDiffMixin(HestonFinDiffMixin):
+    """
+    CEV-Heston PDE coefficients for the generic Douglas ADI engine.
+
+    Generalises the standard Heston asset SDE with a CEV elasticity ``beta``::
+
+        dS = sqrt(v) · S^beta · dW_S
+
+    With ``beta = 1`` this reduces to standard ``HestonFinDiffMixin``.
+
+    Only the asset-direction coefficients differ from Heston:
+
+    * ``aS    = ½ · v · X^(2β)``   (Heston: ½·v·X²)
+    * ``gamma = ρ · ξ · v · X^β``  (Heston: ρ·ξ·v·X)
+
+    The variance-direction coefficients (``aV``, ``bV``) and all boundary
+    conditions are inherited unchanged from ``HestonFinDiffMixin``.
+    """
+
+    def _coefficients(self, X, v):
+        Xc = X[:, None]   # (M+1, 1)
+        vr = v[None, :]   # (1,  L+1)
+        aS    = 0.5 * vr * Xc**(2.0 * self.beta)
+        bS    = np.zeros_like(aS)                  # r = q = 0 (normalized)
+        aV    = 0.5 * self.vov**2 * vr             # unchanged from Heston
+        bV    = self.mr * (self.theta - vr)        # unchanged from Heston
+        gamma = self.rho * self.vov * vr * Xc**self.beta
+        return aS, bS, aV, bV, gamma
+
+
+class HestonCevFinDiff(HestonCevFinDiffMixin, HestonCevABC):
+    """European CEV-Heston option pricing via 2D Douglas ADI finite differences."""

--- a/pyfeng/sv_fin_diff.py
+++ b/pyfeng/sv_fin_diff.py
@@ -512,9 +512,7 @@ from .heston import HestonABC  # noqa: E402
 
 class SabrFinDiff(SabrFinDiffMixin, SabrABC):
     """European SABR option pricing via 2D Douglas ADI finite differences."""
-    _benchmark_file = 'sabr_benchmark.xlsx'
 
 
 class HestonFinDiff(HestonFinDiffMixin, HestonABC):
     """European Heston option pricing via 2D Douglas ADI finite differences."""
-    _benchmark_file = 'heston_benchmark.xlsx'

--- a/pyfeng/sv_fin_diff.py
+++ b/pyfeng/sv_fin_diff.py
@@ -1,0 +1,520 @@
+"""
+Generic 2D Douglas ADI finite-difference mixin for stochastic-volatility models.
+
+Works in normalized forward space (F₀ = 1, r = q = 0 internally).
+Discounting and forward-scaling are handled by the outer ``price()`` method.
+
+The 2D PDE for V(X, v, τ), τ = T − t has the form::
+
+    dV/dτ = (F₀ + F₁ + F₂) V
+
+    F₀: γ(X,v,τ)  · ∂²V/∂X∂v              (explicit; mixed derivative)
+    F₁: aS(X,v,τ) · ∂²V/∂X² + bS(X,v,τ) · ∂V/∂X   (S-direction implicit)
+    F₂: aV(X,v,τ) · ∂²V/∂v² + bV(X,v,τ) · ∂V/∂v   (v-direction implicit)
+
+One Douglas step τₙ → τₙ₊₁ (θ = ½ gives Crank–Nicolson-like accuracy)::
+
+    Y₀ = Vⁿ + dt (F₀ + F₁ + F₂) Vⁿ                  (explicit predictor)
+    (I − θ dt F₁) Y₁ = Y₀ − θ dt F₁ Vⁿ              (S-implicit corrector)
+    (I − θ dt F₂) Vⁿ⁺¹ = Y₁ − θ dt F₂ Vⁿ            (v-implicit corrector)
+
+To use for a new SV model, subclass ``SvFinDiffMixin`` and implement
+four abstract methods: ``_get_v0``, ``_grid_bounds``, ``_coefficients``,
+``_apply_bc``.
+
+References:
+    von Sydow et al. (2019) BENCHOP-SLV, Int. J. Comput. Math.
+    K. in 't Hout & S. Foulon (2010), ADI FD schemes for Heston.
+"""
+
+import abc
+import numpy as np
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Module-level utilities
+# ─────────────────────────────────────────────────────────────────────────────
+
+def _thomas_batch(sub, mid, sup, rhs):
+    """
+    Vectorized Thomas algorithm for batched tridiagonal systems.
+
+    Coefficients ``sub``, ``mid``, ``sup`` are 1-D of length *n* (broadcast
+    across every column of *rhs*) or 2-D of shape *(n, batch)*.  *rhs* has
+    shape *(n, batch)*; the solution has the same shape.
+
+    Equation at row i:  sub[i]·x[i−1] + mid[i]·x[i] + sup[i]·x[i+1] = rhs[i].
+    sub[0] and sup[−1] are unused.
+    """
+    n = mid.shape[0]
+    cp = np.empty_like(np.asarray(mid, dtype=float))
+    dp = np.empty_like(rhs, dtype=float)
+
+    cp[0] = sup[0] / mid[0]
+    dp[0] = rhs[0] / mid[0]
+    for i in range(1, n):
+        denom = mid[i] - sub[i] * cp[i - 1]
+        cp[i] = sup[i] / denom
+        dp[i] = (rhs[i] - sub[i] * dp[i - 1]) / denom
+
+    x = np.empty_like(rhs, dtype=float)
+    x[-1] = dp[-1]
+    for i in range(n - 2, -1, -1):
+        x[i] = dp[i] - cp[i] * x[i + 1]
+    return x
+
+
+def _bilinear(V, S, v, S0, v0):
+    """Bilinear interpolation of grid function V at the point (S0, v0)."""
+    n_S, n_v = len(S), len(v)
+
+    i = int(np.searchsorted(S, S0))
+    i = max(1, min(i, n_S - 1))
+
+    j = int(np.searchsorted(v, v0))
+    j = max(1, min(j, n_v - 1))
+
+    S_lo, S_hi = S[i - 1], S[i]
+    v_lo, v_hi = v[j - 1], v[j]
+    wS = float(np.clip((S0 - S_lo) / (S_hi - S_lo), 0.0, 1.0))
+    wv = float(np.clip((v0 - v_lo) / (v_hi - v_lo), 0.0, 1.0))
+
+    return (
+        (1 - wS) * (1 - wv) * V[i - 1, j - 1]
+        + wS     * (1 - wv) * V[i,     j - 1]
+        + (1 - wS) * wv     * V[i - 1, j    ]
+        + wS       * wv     * V[i,     j    ]
+    )
+
+
+def _standard_bc(V, kk, X, cp):
+    """
+    Standard European call/put boundary conditions in normalized space (r=q=0).
+
+    *   S = 0 (X = X_min):  call → 0,   put → kk
+    *   S = S_max (X = X_max): call → X_max − kk,  put → 0
+    *   v = 0:  intrinsic value (no volatility → no time value)
+    *   v = v_max: Neumann  dV/dv = 0  (V[·, L] = V[·, L−1])
+    """
+    M = len(X) - 1
+    if cp > 0:   # call
+        V[0,  :] = 0.0
+        V[M,  :] = max(X[M] - kk, 0.0)
+        V[:,  0] = np.maximum(X - kk, 0.0)
+    else:        # put
+        V[0,  :] = kk
+        V[M,  :] = 0.0
+        V[:,  0] = np.maximum(kk - X, 0.0)
+    V[:, -1] = V[:, -2]   # Neumann at v_max
+    return V
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Generic ADI mixin
+# ─────────────────────────────────────────────────────────────────────────────
+
+class SvFinDiffMixin(abc.ABC):
+    """
+    Generic Douglas-scheme 2D ADI mixin for stochastic-volatility models.
+
+    Subclass and implement four abstract methods to plug in any model::
+
+        class MyModelFinDiff(SvFinDiffMixin, MyModelABC):
+            def _get_v0(self, fwd, texp):   return ...
+            def _grid_bounds(self, v0, kk, texp): return X_min, X_max, v_max
+            def _coefficients(self, X, v, tau):   return aS, bS, aV, bV, gamma
+            def _apply_bc(self, V, kk, X, cp):    return _standard_bc(V, kk, X, cp)
+
+    The engine works in normalized forward space (X = F/F₀, so X₀ = 1, r=q=0).
+    ``price()`` handles forward/discount scaling externally.
+    """
+
+    # Default numerical parameters — override via set_num_params()
+    n_asset:   int   = 80
+    n_vol:     int   = 40
+    n_time:    int   = 80
+    adi_theta: float = 0.5
+
+    def set_num_params(self, n_asset=80, n_vol=40, n_time=80, adi_theta=0.5):
+        """
+        Configure the ADI grid (consistent with ``set_num_params`` in *_mc.py).
+
+        Args:
+            n_asset:   asset price grid intervals (M)
+            n_vol:     vol/variance grid intervals (L)
+            n_time:    time steps (N)
+            adi_theta: Douglas weight; 0.5 → Crank–Nicolson accuracy
+        """
+        self.n_asset   = int(n_asset)
+        self.n_vol     = int(n_vol)
+        self.n_time    = int(n_time)
+        self.adi_theta = float(adi_theta)
+
+    # ── Abstract interface ────────────────────────────────────────────────────
+
+    @abc.abstractmethod
+    def _get_v0(self, fwd, texp):
+        """
+        Initial vol/variance in the normalized PDE.
+
+        SABR: ``alpha = sigma / fwd^(1−beta)`` via ``SabrABC._variables()``.
+        Heston: ``self.sigma`` (initial variance; scale-free).
+        """
+
+    @abc.abstractmethod
+    def _grid_bounds(self, v0, kk, texp):
+        """
+        Normalized grid boundaries.
+
+        Args:
+            v0:   initial vol/variance (from ``_get_v0``)
+            kk:   normalized strike K/F₀
+            texp: time to expiry
+
+        Returns:
+            (X_min, X_max, v_max)
+        """
+
+    @abc.abstractmethod
+    def _coefficients(self, X, v, tau):
+        """
+        PDE operator coefficients on the full (M+1) × (L+1) grid.
+
+        Args:
+            X:   asset grid, shape (M+1,)
+            v:   vol/variance grid, shape (L+1,)
+            tau: time-to-maturity; pass to callable parameters if time-dependent
+
+        Returns:
+            aS, bS, aV, bV, gamma — each broadcastable to (M+1, L+1).
+
+            aS: (1/2) · diffusion²  in S-direction
+            bS: drift               in S-direction  (0 if F is a martingale)
+            aV: (1/2) · diffusion²  in v-direction
+            bV: drift               in v-direction  (0 for SABR; κ(θ−v) for Heston)
+            gamma: ρ · σ_S · σ_v   (mixed-derivative coefficient)
+        """
+
+    @abc.abstractmethod
+    def _apply_bc(self, V, kk, X, cp):
+        """
+        Boundary conditions in normalized space.
+
+        No discounting (r = q = 0 internally).  For standard European
+        calls/puts return ``_standard_bc(V, kk, X, cp)``.
+        """
+
+    # ── Public pricing entry point ────────────────────────────────────────────
+
+    def price(self, strike, spot, texp, cp=1):
+        """
+        Price European option(s) via Douglas ADI in normalized forward space.
+
+        Loops over strikes (each requires a separate ADI solve because the
+        terminal payoff and boundary conditions depend on K).
+
+        Args:
+            strike: scalar or ndarray of strike prices
+            spot:   spot (or forward when ``is_fwd=True``) price
+            texp:   time to expiry
+            cp:     1 = call, −1 = put
+
+        Returns:
+            Option price(s); same shape as ``strike``.
+        """
+        fwd, df, _ = self._fwd_df_divf(spot, texp)
+        v0  = self._get_v0(fwd, texp)
+        kk  = np.asarray(strike, dtype=float) / fwd   # normalized strike(s)
+        scalar = np.ndim(strike) == 0
+        px  = np.array([self._solve_one(k, v0, texp, cp)
+                        for k in np.atleast_1d(kk).ravel()])
+        result = df * fwd * px
+        return float(result[0]) if scalar else result.reshape(np.shape(strike))
+
+    # ── Core ADI solver ───────────────────────────────────────────────────────
+
+    def _pre_step(self, V, X, v, dX, dv, dt, tau, kk, cp):
+        """
+        Hook called before each Douglas step.
+
+        Override in subclasses to apply model-specific pre-step adjustments,
+        e.g. the degenerate PDE update at v = 0 for Heston.
+        Default: no-op (returns V unchanged).
+        """
+        return V
+
+    def _solve_one(self, kk, v0, texp, cp):
+        """Full Douglas ADI solve in normalized space. Returns price / F₀."""
+        M, L, N = self.n_asset, self.n_vol, self.n_time
+
+        X_min, X_max, v_max = self._grid_bounds(v0, kk, texp)
+        X  = np.linspace(X_min, X_max, M + 1)
+        v  = np.linspace(0.0,   v_max,  L + 1)
+        dX = (X_max - X_min) / M
+        dv = v_max / L
+        dt = texp / N
+
+        # Terminal condition (τ = 0): intrinsic payoff broadcast over v-axis
+        V = np.maximum(cp * (X[:, None] - kk), 0.0) * np.ones((M + 1, L + 1))
+        # v = 0 initial condition is always intrinsic (τ = 0 payoff)
+        V[:, 0] = np.maximum(cp * (X - kk), 0.0)
+        V = self._apply_bc(V, kk, X, cp)
+
+        for n in range(N):
+            tau_old = n * dt
+            tau_new = (n + 1) * dt
+            V = self._pre_step(V, X, v, dX, dv, dt, tau_old, kk, cp)
+            V = self._step(V, X, v, dX, dv, dt, tau_old, tau_new, kk, cp)
+
+        return _bilinear(V, X, v, 1.0, v0)
+
+    def _step(self, V, X, v, dX, dv, dt, tau_old, tau_new, kk, cp):
+        """One Douglas step: advance V from τ_old to τ_new."""
+        adt     = self.adi_theta * dt
+        tau_mid = 0.5 * (tau_old + tau_new)
+
+        aS, bS, aV, bV, gamma = self._coefficients(X, v, tau_mid)
+
+        F0V = self._F0(V, gamma, dX, dv)
+        F1V = self._F1(V, aS, bS, dX)
+        F2V = self._F2(V, aV, bV, dv)
+
+        Y0 = V + dt * (F0V + F1V + F2V)
+        Y0 = self._apply_bc(Y0, kk, X, cp)
+
+        Y1  = self._solve_S_implicit(Y0 - adt * F1V, adt, aS, bS, dX, X, kk, cp)
+        Vn  = self._solve_v_implicit(Y1 - adt * F2V, adt, aV, bV, dv, X, kk, cp)
+        return Vn
+
+    # ── Spatial operators ─────────────────────────────────────────────────────
+
+    @staticmethod
+    def _F0(V, gamma, dX, dv):
+        """Mixed cross-derivative operator (explicit)."""
+        out = np.zeros_like(V)
+        out[1:-1, 1:-1] = (
+            gamma[1:-1, 1:-1]
+            * (V[2:, 2:] - V[2:, :-2] - V[:-2, 2:] + V[:-2, :-2])
+            / (4.0 * dX * dv)
+        )
+        return out
+
+    @staticmethod
+    def _F1(V, aS, bS, dX):
+        """Asset-direction differential operator."""
+        out = np.zeros_like(V)
+        a = aS[1:-1, :] / dX**2      # (M-1, L+1) or broadcasts
+        b = bS[1:-1, :] / (2.0 * dX)
+        out[1:-1, :] = (
+            a * (V[2:, :] - 2.0 * V[1:-1, :] + V[:-2, :])
+            + b * (V[2:, :] - V[:-2, :])
+        )
+        return out
+
+    @staticmethod
+    def _F2(V, aV, bV, dv):
+        """Vol-direction differential operator."""
+        out = np.zeros_like(V)
+        # aV, bV are (1, L+1) or (M+1, L+1); slice interior v-axis
+        c = aV[..., 1:-1] / dv**2
+        d = bV[..., 1:-1] / (2.0 * dv)
+        out[:, 1:-1] = (
+            c * (V[:, 2:] - 2.0 * V[:, 1:-1] + V[:, :-2])
+            + d * (V[:, 2:] - V[:, :-2])
+        )
+        return out
+
+    # ── Implicit sweeps (Thomas algorithm) ───────────────────────────────────
+
+    def _solve_S_implicit(self, rhs, adt, aS, bS, dX, X, kk, cp):
+        """Solve (I − adt·F₁)Y = rhs for interior S-points, all interior v."""
+        M, L = self.n_asset, self.n_vol
+        Y = self._apply_bc(rhs.copy(), kk, X, cp)
+
+        # Coefficient arrays for interior (i=1..M-1, j=1..L-1)
+        a = aS[1:M, 1:L] / dX**2      # (M-1, L-1)
+        b = bS[1:M, 1:L] / (2.0 * dX) # (M-1, L-1)
+
+        sub = -adt * (a - b)
+        mid =  1.0 + adt * 2.0 * a
+        sup = -adt * (a + b)
+
+        rhs_int = rhs[1:M, 1:L].copy()
+        # Fold known boundary S-values into right-hand side
+        rhs_int[0,  :] -= sub[0,  :] * Y[0,  1:L]
+        rhs_int[-1, :] -= sup[-1, :] * Y[M,  1:L]
+
+        Y[1:M, 1:L] = _thomas_batch(sub, mid, sup, rhs_int)
+        return self._apply_bc(Y, kk, X, cp)
+
+    def _solve_v_implicit(self, rhs, adt, aV, bV, dv, X, kk, cp):
+        """Solve (I − adt·F₂)Y = rhs for interior v-points, all S."""
+        M, L = self.n_asset, self.n_vol
+        Y = self._apply_bc(rhs.copy(), kk, X, cp)
+
+        # Extract 1-D interior v-coefficients  (aV, bV may be (1,L+1))
+        av = np.asarray(aV).ravel() if aV.shape[0] == 1 else aV[0]
+        bv = np.asarray(bV).ravel() if bV.shape[0] == 1 else bV[0]
+        c = av[1:L] / dv**2    # (L-1,)
+        d = bv[1:L] / (2.0 * dv)
+
+        sub = -adt * (c - d)
+        mid =  1.0 + adt * 2.0 * c
+        sup = -adt * (c + d)
+
+        # Neumann BC at v_max: V[:, L] = V[:, L-1]  →  fold last sup into diagonal
+        mid_eff = mid.copy()
+        mid_eff[-1] += sup[-1]
+
+        # Transpose so v-axis is first (Thomas iterates along v)
+        rhs_int = rhs[:, 1:L].T.copy()       # (L-1, M+1)
+        rhs_int[0, :] -= sub[0] * Y[:, 0]    # Dirichlet at v = 0
+
+        sol = _thomas_batch(sub, mid_eff, sup, rhs_int)  # (L-1, M+1)
+        Y[:, 1:L] = sol.T
+        Y[:, L]   = Y[:, L - 1]              # enforce Neumann mirror
+        return self._apply_bc(Y, kk, X, cp)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# SABR mixin
+# ─────────────────────────────────────────────────────────────────────────────
+
+class SabrFinDiffMixin(SvFinDiffMixin):
+    """
+    SABR PDE coefficients for the generic Douglas ADI engine.
+
+    PyFENG parameter mapping:
+        ``sigma`` → σ₀ (initial vol level)
+        ``beta``  → β  (CEV elasticity)
+        ``vov``   → ν  (vol-of-vol)
+        ``rho``   → ρ  (correlation)
+
+    In the normalized forward space (X = F/F₀) the effective initial vol
+    is  α = σ₀ / F₀^(1−β),  computed by ``SabrABC._variables(fwd, texp)``.
+    """
+
+    def _get_v0(self, fwd, texp):
+        alpha, *_ = self._variables(fwd, texp)   # SabrABC helper
+        return float(alpha)
+
+    def _grid_bounds(self, v0, kk, texp):
+        sq    = np.sqrt(max(texp, 0.0))
+        X_ref = max(1.0, float(kk))
+        X_max = max(4.0 * X_ref,
+                    X_ref + 5.0 * v0 * (X_ref ** self.beta) * sq)
+        v_max = max(1.0, 5.0 * v0,
+                    v0 * (1.0 + 4.0 * self.vov * sq))
+        X_min = 0.0 if self.beta > 0.0 else min(0.0, 1.0 - 5.0 * v0 * sq)
+        return float(X_min), float(X_max), float(v_max)
+
+    def _coefficients(self, X, v, tau):
+        Xc = X[:, None]   # (M+1, 1)
+        vr = v[None, :]   # (1,  L+1)
+        aS    = 0.5 * vr**2 * Xc**(2.0 * self.beta)
+        bS    = np.zeros_like(aS)                  # F is a martingale (r = q = 0)
+        aV    = 0.5 * self.vov**2 * vr**2          # (1, L+1) — depends on v only
+        bV    = np.zeros_like(aV)                  # SABR vol is a martingale
+        gamma = self.rho * self.vov * vr**2 * Xc**self.beta
+        return aS, bS, aV, bV, gamma
+
+    def _apply_bc(self, V, kk, X, cp):
+        return _standard_bc(V, kk, X, cp)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Heston mixin
+# ─────────────────────────────────────────────────────────────────────────────
+
+class HestonFinDiffMixin(SvFinDiffMixin):
+    """
+    Heston PDE coefficients for the generic Douglas ADI engine.
+
+    PyFENG parameter mapping:
+        ``sigma`` → v₀ (initial variance)
+        ``vov``   → ξ  (CIR diffusion coefficient, vol-of-vol)
+        ``mr``    → κ  (mean-reversion speed)
+        ``theta`` → θ  (long-run variance)
+        ``rho``   → ρ  (correlation)
+
+    The variance process is scale-free so no forward normalization is needed.
+
+    Boundary at v = 0:
+        When the Feller condition 2κθ ≥ ξ² is violated the variance can reach
+        zero and the PDE degenerates to  ∂V/∂τ = κθ ∂V/∂v.  This is integrated
+        explicitly via ``_pre_step`` at every time step rather than freezing the
+        option value at the intrinsic payoff (which would under-price options
+        with positive expected variance recovery).
+    """
+
+    def _get_v0(self, fwd, texp):
+        return float(self.sigma)   # initial variance; no fwd dependency
+
+    def _grid_bounds(self, v0, kk, texp):
+        X_max = max(4.0 * max(1.0, float(kk)),
+                    1.0 + 5.0 * np.sqrt(v0 * max(texp, 0.0)))
+        # CIR stationary std dev: ξ · √(θ / (2κ))
+        cir_std = self.vov * np.sqrt(
+            max(self.theta, 1e-8) / (2.0 * max(self.mr, 1e-8))
+        )
+        v_max = max(5.0 * float(v0), self.theta + 5.0 * cir_std)
+        return 0.0, float(X_max), float(v_max)
+
+    def _coefficients(self, X, v, tau):
+        Xc = X[:, None]   # (M+1, 1)
+        vr = v[None, :]   # (1,  L+1)
+        aS    = 0.5 * vr * Xc**2
+        bS    = np.zeros_like(aS)                  # r = q = 0 (normalized)
+        aV    = 0.5 * self.vov**2 * vr             # (1, L+1)
+        bV    = self.mr * (self.theta - vr)        # mean-reverting CIR drift
+        gamma = self.rho * self.vov * vr * Xc
+        return aS, bS, aV, bV, gamma
+
+    def _apply_bc(self, V, kk, X, cp):
+        """
+        Heston boundary conditions.
+
+        S = 0:     call → 0,       put → kk   (absorbing)
+        S = S_max: call → X_max−kk, put → 0  (linear extrapolation)
+        v = v_max: Neumann  dV/dv = 0         (far-field)
+        v = 0:     NOT reset here — handled by ``_pre_step`` via the
+                   degenerate PDE  ∂V/∂τ = κθ ∂V/∂v.
+        """
+        M = len(X) - 1
+        if cp > 0:
+            V[0,  :] = 0.0
+            V[M,  :] = max(X[M] - kk, 0.0)
+        else:
+            V[0,  :] = kk
+            V[M,  :] = 0.0
+        V[:, -1] = V[:, -2]   # Neumann at v_max
+        return V
+
+    def _pre_step(self, V, X, v, dX, dv, dt, tau, kk, cp):
+        """
+        Explicit degenerate PDE step at v = 0.
+
+        Integrates  ∂V/∂τ = κθ (V[:,1] − V[:,0]) / dv  for one time step
+        using forward Euler before the Douglas ADI sweep, then re-applies the
+        S-direction and v_max boundary conditions.
+        """
+        V[:, 0] += dt * self.mr * self.theta * (V[:, 1] - V[:, 0]) / dv
+        return self._apply_bc(V, kk, X, cp)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Concrete classes
+# ─────────────────────────────────────────────────────────────────────────────
+
+from .sabr import SabrABC      # noqa: E402
+from .heston import HestonABC  # noqa: E402
+
+
+class SabrFinDiff(SabrFinDiffMixin, SabrABC):
+    """European SABR option pricing via 2D Douglas ADI finite differences."""
+    model_type = 'SabrFinDiff'
+
+
+class HestonFinDiff(HestonFinDiffMixin, HestonABC):
+    """European Heston option pricing via 2D Douglas ADI finite differences."""
+    model_type = 'HestonFinDiff'

--- a/tests/test_sv_fin_diff.py
+++ b/tests/test_sv_fin_diff.py
@@ -31,10 +31,10 @@ def test_sabr_adi_benchop(set_no):
     Tolerance: abs=3e-3 (consistent with the BENCHOP-SLV paper error budget).
     """
     m, df, info = pf.SabrFinDiff.init_benchmark(set_no)
-    m.set_num_params(n_asset=80, n_vol=40, n_time=80)
+    m.set_num_params(n_grid=(80, 80, 40))
 
-    args = info["args_pricing"]
-    prices = m.price(args["strike"], args["spot"], args["texp"], cp=1)
+    args   = info["args_pricing"]
+    prices = m.price(**args)
     refs   = info["val"]
 
     for K, p, r in zip(args["strike"], prices, refs):
@@ -59,10 +59,10 @@ def test_heston_adi_benchop():
     tolerances require Richardson extrapolation or finer grids.
     """
     m, df, info = pf.HestonFinDiff.init_benchmark(10)
-    m.set_num_params(n_asset=80, n_vol=40, n_time=80)
+    m.set_num_params(n_grid=(80, 80, 40))
 
-    args  = info["args_pricing"]
-    prices = m.price(args["strike"], args["spot"], args["texp"], cp=1)
+    args   = info["args_pricing"]
+    prices = m.price(**args)
     refs   = info["val"]
 
     for K, p, r in zip(args["strike"], prices, refs):
@@ -78,7 +78,7 @@ def test_heston_adi_benchop():
 def test_sabr_put_call_parity():
     """SABR put-call parity: C − P = S₀ − K (r = 0)."""
     m, _, info = pf.SabrFinDiff.init_benchmark(20)
-    m.set_num_params(n_asset=80, n_vol=40, n_time=80)
+    m.set_num_params(n_grid=(80, 80, 40))
 
     args = info["args_pricing"]
     S0 = args["spot"]; K = float(args["strike"][1])  # ATM strike
@@ -92,7 +92,7 @@ def test_sabr_put_call_parity():
 def test_heston_put_call_parity():
     """Heston put-call parity at ATM: C − P = S₀ − K (r = 0)."""
     m, _, info = pf.HestonFinDiff.init_benchmark(10)
-    m.set_num_params(n_asset=80, n_vol=40, n_time=80)
+    m.set_num_params(n_grid=(80, 80, 40))
 
     args = info["args_pricing"]
     S0 = float(args["spot"]); K = float(args["strike"][1])  # ATM strike (K=100)
@@ -110,10 +110,10 @@ def test_heston_put_call_parity():
 def test_sabr_array_strikes():
     """price() should accept an ndarray of strikes and return the same shape."""
     m, _, info = pf.SabrFinDiff.init_benchmark(20)
-    m.set_num_params(n_asset=80, n_vol=40, n_time=80)
+    m.set_num_params(n_grid=(80, 80, 40))
 
-    args = info["args_pricing"]
-    prices = m.price(args["strike"], args["spot"], args["texp"], cp=1)
+    args   = info["args_pricing"]
+    prices = m.price(**args)
     assert prices.shape == args["strike"].shape
     assert np.all(prices > 0)
 
@@ -121,9 +121,9 @@ def test_sabr_array_strikes():
 def test_heston_positive_price():
     """Heston ATM call is positive and finite."""
     m, _, info = pf.HestonFinDiff.init_benchmark(10)
-    m.set_num_params(n_asset=80, n_vol=40, n_time=80)
+    m.set_num_params(n_grid=(80, 80, 40))
 
-    args = info["args_pricing"]
+    args  = info["args_pricing"]
     price = m.price(float(args["strike"][1]), float(args["spot"]), args["texp"], cp=1)
     assert np.isfinite(price)
     assert price > 0

--- a/tests/test_sv_fin_diff.py
+++ b/tests/test_sv_fin_diff.py
@@ -118,6 +118,44 @@ def test_sabr_array_strikes():
     assert np.all(prices > 0)
 
 
+def test_degenerate_to_cev():
+    """With vov→0, both SabrFinDiff and HestonCevFinDiff reduce to pure CEV.
+
+    SABR (vov→0):      dF = sigma · F^beta · dW  →  CEV with sigma_cev = m.sigma
+    HestonCev (vov→0): dS = sqrt(v) · S^beta · dW, v frozen at sigma
+                                                  →  CEV with sigma_cev = sqrt(m.sigma)
+
+    Strong mr pins the Heston variance tightly to sigma=theta; Feller is satisfied
+    (2κθ >> ξ²) so the v=0 boundary uses the stable Dirichlet condition.
+    Tolerance abs=1e-3: residual error is O(vov²) plus finite-grid discretisation.
+    """
+    beta = 0.5
+    S0, texp = 1.0, 1.0
+    strikes = np.array([0.8, 1.0, 1.2])
+
+    # SABR with vov→0: effective CEV vol = m_sabr.sigma
+    m_sabr = pf.SabrFinDiff(sigma=0.3, vov=1e-4, rho=0.0, beta=beta)
+    m_sabr.set_num_params(n_grid=(80, 80, 40))
+    p_sabr = m_sabr.price(strikes, S0, texp, cp=1)
+
+    # HestonCev with vov→0, strong mr: variance frozen at sigma=theta,
+    # effective CEV vol = sqrt(m_hcev.sigma)
+    m_hcev = pf.HestonCevFinDiff(sigma=0.09, vov=1e-4, mr=100.0, theta=0.09, rho=0.0, beta=beta)
+    m_hcev.set_num_params(n_grid=(80, 80, 40))
+    p_hcev = m_hcev.price(strikes, S0, texp, cp=1)
+
+    # Both converge to the same CEV: sigma_cev = m_sabr.sigma = sqrt(m_hcev.sigma)
+    p_ref = pf.Cev(sigma=np.sqrt(m_hcev.sigma), beta=beta).price(strikes, S0, texp, cp=1)
+
+    for K, pr, ps, ph in zip(strikes, p_ref, p_sabr, p_hcev):
+        assert ps == pytest.approx(pr, abs=1e-3), (
+            f"SABR→CEV  K={K}: got {ps:.6f}, expected {pr:.6f}"
+        )
+        assert ph == pytest.approx(pr, abs=1e-3), (
+            f"HestonCev→CEV  K={K}: got {ph:.6f}, expected {pr:.6f}"
+        )
+
+
 def test_heston_positive_price():
     """Heston ATM call is positive and finite."""
     m, _, info = pf.HestonFinDiff.init_benchmark(10)

--- a/tests/test_sv_fin_diff.py
+++ b/tests/test_sv_fin_diff.py
@@ -1,156 +1,129 @@
 """
 Benchmark tests for sv_fin_diff.py — 2D Douglas ADI finite-difference mixin.
 
-Reference: von Sydow et al. (2019) BENCHOP-SLV, Int. J. Comput. Math.
-           Sets I and II correspond to the paper's SABR test problems.
-           Heston set uses parameters from the paper's §2.2 Heston benchmark.
+Parameters and reference values are loaded from the PyFENG benchmark Excel files
+via Class.init_benchmark(no):
+
+    SabrFinDiff.init_benchmark(20)  → BENCHOP-SLV Set I
+    SabrFinDiff.init_benchmark(21)  → BENCHOP-SLV Set II
+    HestonFinDiff.init_benchmark(10) → BENCHOP-SLV Heston Set I
+
+Reference: von Sydow et al. (2018) BENCHOP-SLV, Int. J. Comput. Math.
+https://doi.org/10.1080/00207160.2018.1544368
 """
 
 import numpy as np
 import pytest
-import sys
-import os
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 import pyfeng as pf
 
 
 # ─────────────────────────────────────────────────────────────────────────────
-# SABR Set I  (BENCHOP-SLV §2.1, parameter set I)
-#   S0 = 0.5, σ₀ = α = 0.5, β = 0.5, ρ = 0, ν = 0.4, T = 2, r = 0
+# SABR benchmark sets
 # ─────────────────────────────────────────────────────────────────────────────
 
-SABR_SET_I = dict(sigma=0.5, beta=0.5, rho=0.0, vov=0.4)
-SABR_SET_I_SPOT = 0.5
-SABR_SET_I_TEXP = 2.0
-SABR_SET_I_ROWS = [
-    (0.434062, 0.221383196830866),
-    (0.500000, 0.193836689413803),
-    (0.575955, 0.166240814653231),
-]
+@pytest.mark.parametrize("set_no", [20, 21])
+def test_sabr_adi_benchop(set_no):
+    """BENCHOP-SLV SABR sets 20 (Set I) and 21 (Set II).
 
-# ─────────────────────────────────────────────────────────────────────────────
-# SABR Set II  (BENCHOP-SLV §2.1, parameter set II)
-#   S0 = 0.07, σ₀ = α = 0.4, β = 0.5, ρ = −0.6, ν = 0.8, T = 10, r = 0
-# ─────────────────────────────────────────────────────────────────────────────
-
-SABR_SET_II = dict(sigma=0.4, beta=0.5, rho=-0.6, vov=0.8)
-SABR_SET_II_SPOT = 0.07
-SABR_SET_II_TEXP = 10.0
-SABR_SET_II_ROWS = [
-    (0.051023, 0.052450313614407),
-    (0.070000, 0.046658753491306),
-    (0.096036, 0.039291470612989),
-]
-
-# ─────────────────────────────────────────────────────────────────────────────
-# Heston Set  (BENCHOP-SLV §2.2)
-#   K = 100, T = 1, κ = 2.58, θ = 0.043, ξ = 1, ρ = −0.36, V₀ = 0.114
-# ─────────────────────────────────────────────────────────────────────────────
-
-HESTON_PARAMS = dict(sigma=0.114, vov=1.0, mr=2.58, theta=0.043, rho=-0.36)
-HESTON_STRIKE = 100.0
-HESTON_TEXP = 1.0
-HESTON_ROWS = [
-    (75.0,  0.908502728459621),
-    (100.0, 9.046650119220966),
-    (125.0, 28.514786399298796),
-]
-
-
-# ─────────────────────────────────────────────────────────────────────────────
-# SABR tests
-# ─────────────────────────────────────────────────────────────────────────────
-
-@pytest.mark.parametrize("strike,ref", SABR_SET_I_ROWS)
-def test_sabr_set_i(strike, ref):
-    """BENCHOP-SLV parameter set I: β=0.5, ρ=0, T=2."""
-    m = pf.SabrFinDiff(**SABR_SET_I)
-    m.set_num_params(n_asset=80, n_vol=40, n_time=80)
-    price = m.price(strike, SABR_SET_I_SPOT, SABR_SET_I_TEXP, cp=1)
-    assert price == pytest.approx(ref, abs=3e-3), (
-        f"Set I K={strike:.6f}: got {price:.6f}, expected {ref:.6f}"
-    )
-
-
-@pytest.mark.parametrize("strike,ref", SABR_SET_II_ROWS)
-def test_sabr_set_ii(strike, ref):
-    """BENCHOP-SLV parameter set II: β=0.5, ρ=−0.6, T=10."""
-    m = pf.SabrFinDiff(**SABR_SET_II)
-    m.set_num_params(n_asset=80, n_vol=40, n_time=80)
-    price = m.price(strike, SABR_SET_II_SPOT, SABR_SET_II_TEXP, cp=1)
-    assert price == pytest.approx(ref, abs=3e-3), (
-        f"Set II K={strike:.6f}: got {price:.6f}, expected {ref:.6f}"
-    )
-
-
-# ─────────────────────────────────────────────────────────────────────────────
-# Heston tests
-# ─────────────────────────────────────────────────────────────────────────────
-
-@pytest.mark.parametrize("spot,ref", HESTON_ROWS)
-def test_heston_benchop(spot, ref):
-    """BENCHOP-SLV Heston: κ=2.58, θ=0.043, ξ=1, ρ=−0.36, V₀=0.114, K=100, T=1.
-
-    Note: these parameters violate the Feller condition (2κθ = 0.22 < ξ² = 1),
-    making convergence with uniform grids slower than for well-conditioned cases.
-    The solver matches the reference to within ~1–2 % for a coarse (80×40×80) grid.
-    Tighter tolerances require Richardson extrapolation or finer grids.
+    Set 20: S0=0.5, σ₀=0.5, β=0.5, ρ=0, ν=0.4, T=2
+    Set 21: S0=0.07, σ₀=0.4, β=0.5, ρ=−0.6, ν=0.8, T=10
+    Tolerance: abs=3e-3 (consistent with the BENCHOP-SLV paper error budget).
     """
-    m = pf.HestonFinDiff(**HESTON_PARAMS)
+    m, df, info = pf.SabrFinDiff.init_benchmark(set_no)
     m.set_num_params(n_asset=80, n_vol=40, n_time=80)
-    price = m.price(HESTON_STRIKE, spot, HESTON_TEXP, cp=1)
-    assert price == pytest.approx(ref, abs=0.15), (
-        f"Heston S0={spot}: got {price:.6f}, expected {ref:.6f}"
-    )
+
+    args = info["args_pricing"]
+    prices = m.price(args["strike"], args["spot"], args["texp"], cp=1)
+    refs   = info["val"]
+
+    for K, p, r in zip(args["strike"], prices, refs):
+        assert p == pytest.approx(r, abs=3e-3), (
+            f"SABR set {set_no} K={K:.6f}: got {p:.6f}, expected {r:.6f}"
+        )
 
 
 # ─────────────────────────────────────────────────────────────────────────────
-# Put-call parity (normalized space: C − P ≈ F·e^{-rT} − K·e^{-rT} = S0 − K when r=0)
+# Heston benchmark set
+# ─────────────────────────────────────────────────────────────────────────────
+
+def test_heston_adi_benchop():
+    """BENCHOP-SLV Heston Set I (set 10).
+
+    S0=100, K∈{133.33, 100, 80}, T=1
+    κ=2.58, θ=0.043, ξ=1, ρ=−0.36, V₀=0.114
+
+    Note: these parameters violate the Feller condition (2κθ=0.22 < ξ²=1),
+    making convergence with uniform grids slower than for well-conditioned
+    cases.  The coarse (80×40×80) grid achieves ~1–2 % relative error; tighter
+    tolerances require Richardson extrapolation or finer grids.
+    """
+    m, df, info = pf.HestonFinDiff.init_benchmark(10)
+    m.set_num_params(n_asset=80, n_vol=40, n_time=80)
+
+    args  = info["args_pricing"]
+    prices = m.price(args["strike"], args["spot"], args["texp"], cp=1)
+    refs   = info["val"]
+
+    for K, p, r in zip(args["strike"], prices, refs):
+        assert p == pytest.approx(r, abs=0.15), (
+            f"Heston set 10 K={K:.4f}: got {p:.6f}, expected {r:.6f}"
+        )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Put-call parity  (normalized space: C − P = S₀ − K  when r = 0)
 # ─────────────────────────────────────────────────────────────────────────────
 
 def test_sabr_put_call_parity():
-    """Put-call parity: C − P = S0 − K (r=0)."""
-    m = pf.SabrFinDiff(**SABR_SET_I)
+    """SABR put-call parity: C − P = S₀ − K (r = 0)."""
+    m, _, info = pf.SabrFinDiff.init_benchmark(20)
     m.set_num_params(n_asset=80, n_vol=40, n_time=80)
-    S0, K, T = SABR_SET_I_SPOT, 0.500000, SABR_SET_I_TEXP
-    call = m.price(K, S0, T, cp=1)
-    put  = m.price(K, S0, T, cp=-1)
+
+    args = info["args_pricing"]
+    S0 = args["spot"]; K = float(args["strike"][1])  # ATM strike
+    call = m.price(K, S0, args["texp"], cp=1)
+    put  = m.price(K, S0, args["texp"], cp=-1)
     assert call - put == pytest.approx(S0 - K, abs=1e-3), (
-        f"PCP violation: C-P={call-put:.6f}, S0-K={S0-K:.6f}"
+        f"SABR PCP: C−P={call-put:.6f}, S₀−K={S0-K:.6f}"
     )
 
 
 def test_heston_put_call_parity():
-    """Put-call parity for Heston at-the-money (r=0)."""
-    m = pf.HestonFinDiff(**HESTON_PARAMS)
+    """Heston put-call parity at ATM: C − P = S₀ − K (r = 0)."""
+    m, _, info = pf.HestonFinDiff.init_benchmark(10)
     m.set_num_params(n_asset=80, n_vol=40, n_time=80)
-    S0, K, T = 100.0, 100.0, HESTON_TEXP
-    call = m.price(K, S0, T, cp=1)
-    put  = m.price(K, S0, T, cp=-1)
+
+    args = info["args_pricing"]
+    S0 = float(args["spot"]); K = float(args["strike"][1])  # ATM strike (K=100)
+    call = m.price(K, S0, args["texp"], cp=1)
+    put  = m.price(K, S0, args["texp"], cp=-1)
     assert call - put == pytest.approx(S0 - K, abs=1e-2), (
-        f"PCP violation: C-P={call-put:.6f}, S0-K={S0-K:.6f}"
+        f"Heston PCP: C−P={call-put:.6f}, S₀−K={S0-K:.6f}"
     )
 
 
 # ─────────────────────────────────────────────────────────────────────────────
-# Smoke tests: array input and positive prices
+# Smoke tests
 # ─────────────────────────────────────────────────────────────────────────────
 
 def test_sabr_array_strikes():
-    """price() should accept an ndarray of strikes and return same shape."""
-    m = pf.SabrFinDiff(**SABR_SET_I)
+    """price() should accept an ndarray of strikes and return the same shape."""
+    m, _, info = pf.SabrFinDiff.init_benchmark(20)
     m.set_num_params(n_asset=80, n_vol=40, n_time=80)
-    strikes = np.array([k for k, _ in SABR_SET_I_ROWS])
-    prices = m.price(strikes, SABR_SET_I_SPOT, SABR_SET_I_TEXP, cp=1)
-    assert prices.shape == strikes.shape
+
+    args = info["args_pricing"]
+    prices = m.price(args["strike"], args["spot"], args["texp"], cp=1)
+    assert prices.shape == args["strike"].shape
     assert np.all(prices > 0)
 
 
 def test_heston_positive_price():
-    """Spot check: Heston ATM call is positive and finite."""
-    m = pf.HestonFinDiff(**HESTON_PARAMS)
+    """Heston ATM call is positive and finite."""
+    m, _, info = pf.HestonFinDiff.init_benchmark(10)
     m.set_num_params(n_asset=80, n_vol=40, n_time=80)
-    price = m.price(100.0, 100.0, HESTON_TEXP, cp=1)
+
+    args = info["args_pricing"]
+    price = m.price(float(args["strike"][1]), float(args["spot"]), args["texp"], cp=1)
     assert np.isfinite(price)
     assert price > 0

--- a/tests/test_sv_fin_diff.py
+++ b/tests/test_sv_fin_diff.py
@@ -1,0 +1,156 @@
+"""
+Benchmark tests for sv_fin_diff.py — 2D Douglas ADI finite-difference mixin.
+
+Reference: von Sydow et al. (2019) BENCHOP-SLV, Int. J. Comput. Math.
+           Sets I and II correspond to the paper's SABR test problems.
+           Heston set uses parameters from the paper's §2.2 Heston benchmark.
+"""
+
+import numpy as np
+import pytest
+import sys
+import os
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+import pyfeng as pf
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# SABR Set I  (BENCHOP-SLV §2.1, parameter set I)
+#   S0 = 0.5, σ₀ = α = 0.5, β = 0.5, ρ = 0, ν = 0.4, T = 2, r = 0
+# ─────────────────────────────────────────────────────────────────────────────
+
+SABR_SET_I = dict(sigma=0.5, beta=0.5, rho=0.0, vov=0.4)
+SABR_SET_I_SPOT = 0.5
+SABR_SET_I_TEXP = 2.0
+SABR_SET_I_ROWS = [
+    (0.434062, 0.221383196830866),
+    (0.500000, 0.193836689413803),
+    (0.575955, 0.166240814653231),
+]
+
+# ─────────────────────────────────────────────────────────────────────────────
+# SABR Set II  (BENCHOP-SLV §2.1, parameter set II)
+#   S0 = 0.07, σ₀ = α = 0.4, β = 0.5, ρ = −0.6, ν = 0.8, T = 10, r = 0
+# ─────────────────────────────────────────────────────────────────────────────
+
+SABR_SET_II = dict(sigma=0.4, beta=0.5, rho=-0.6, vov=0.8)
+SABR_SET_II_SPOT = 0.07
+SABR_SET_II_TEXP = 10.0
+SABR_SET_II_ROWS = [
+    (0.051023, 0.052450313614407),
+    (0.070000, 0.046658753491306),
+    (0.096036, 0.039291470612989),
+]
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Heston Set  (BENCHOP-SLV §2.2)
+#   K = 100, T = 1, κ = 2.58, θ = 0.043, ξ = 1, ρ = −0.36, V₀ = 0.114
+# ─────────────────────────────────────────────────────────────────────────────
+
+HESTON_PARAMS = dict(sigma=0.114, vov=1.0, mr=2.58, theta=0.043, rho=-0.36)
+HESTON_STRIKE = 100.0
+HESTON_TEXP = 1.0
+HESTON_ROWS = [
+    (75.0,  0.908502728459621),
+    (100.0, 9.046650119220966),
+    (125.0, 28.514786399298796),
+]
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# SABR tests
+# ─────────────────────────────────────────────────────────────────────────────
+
+@pytest.mark.parametrize("strike,ref", SABR_SET_I_ROWS)
+def test_sabr_set_i(strike, ref):
+    """BENCHOP-SLV parameter set I: β=0.5, ρ=0, T=2."""
+    m = pf.SabrFinDiff(**SABR_SET_I)
+    m.set_num_params(n_asset=80, n_vol=40, n_time=80)
+    price = m.price(strike, SABR_SET_I_SPOT, SABR_SET_I_TEXP, cp=1)
+    assert price == pytest.approx(ref, abs=3e-3), (
+        f"Set I K={strike:.6f}: got {price:.6f}, expected {ref:.6f}"
+    )
+
+
+@pytest.mark.parametrize("strike,ref", SABR_SET_II_ROWS)
+def test_sabr_set_ii(strike, ref):
+    """BENCHOP-SLV parameter set II: β=0.5, ρ=−0.6, T=10."""
+    m = pf.SabrFinDiff(**SABR_SET_II)
+    m.set_num_params(n_asset=80, n_vol=40, n_time=80)
+    price = m.price(strike, SABR_SET_II_SPOT, SABR_SET_II_TEXP, cp=1)
+    assert price == pytest.approx(ref, abs=3e-3), (
+        f"Set II K={strike:.6f}: got {price:.6f}, expected {ref:.6f}"
+    )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Heston tests
+# ─────────────────────────────────────────────────────────────────────────────
+
+@pytest.mark.parametrize("spot,ref", HESTON_ROWS)
+def test_heston_benchop(spot, ref):
+    """BENCHOP-SLV Heston: κ=2.58, θ=0.043, ξ=1, ρ=−0.36, V₀=0.114, K=100, T=1.
+
+    Note: these parameters violate the Feller condition (2κθ = 0.22 < ξ² = 1),
+    making convergence with uniform grids slower than for well-conditioned cases.
+    The solver matches the reference to within ~1–2 % for a coarse (80×40×80) grid.
+    Tighter tolerances require Richardson extrapolation or finer grids.
+    """
+    m = pf.HestonFinDiff(**HESTON_PARAMS)
+    m.set_num_params(n_asset=80, n_vol=40, n_time=80)
+    price = m.price(HESTON_STRIKE, spot, HESTON_TEXP, cp=1)
+    assert price == pytest.approx(ref, abs=0.15), (
+        f"Heston S0={spot}: got {price:.6f}, expected {ref:.6f}"
+    )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Put-call parity (normalized space: C − P ≈ F·e^{-rT} − K·e^{-rT} = S0 − K when r=0)
+# ─────────────────────────────────────────────────────────────────────────────
+
+def test_sabr_put_call_parity():
+    """Put-call parity: C − P = S0 − K (r=0)."""
+    m = pf.SabrFinDiff(**SABR_SET_I)
+    m.set_num_params(n_asset=80, n_vol=40, n_time=80)
+    S0, K, T = SABR_SET_I_SPOT, 0.500000, SABR_SET_I_TEXP
+    call = m.price(K, S0, T, cp=1)
+    put  = m.price(K, S0, T, cp=-1)
+    assert call - put == pytest.approx(S0 - K, abs=1e-3), (
+        f"PCP violation: C-P={call-put:.6f}, S0-K={S0-K:.6f}"
+    )
+
+
+def test_heston_put_call_parity():
+    """Put-call parity for Heston at-the-money (r=0)."""
+    m = pf.HestonFinDiff(**HESTON_PARAMS)
+    m.set_num_params(n_asset=80, n_vol=40, n_time=80)
+    S0, K, T = 100.0, 100.0, HESTON_TEXP
+    call = m.price(K, S0, T, cp=1)
+    put  = m.price(K, S0, T, cp=-1)
+    assert call - put == pytest.approx(S0 - K, abs=1e-2), (
+        f"PCP violation: C-P={call-put:.6f}, S0-K={S0-K:.6f}"
+    )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Smoke tests: array input and positive prices
+# ─────────────────────────────────────────────────────────────────────────────
+
+def test_sabr_array_strikes():
+    """price() should accept an ndarray of strikes and return same shape."""
+    m = pf.SabrFinDiff(**SABR_SET_I)
+    m.set_num_params(n_asset=80, n_vol=40, n_time=80)
+    strikes = np.array([k for k, _ in SABR_SET_I_ROWS])
+    prices = m.price(strikes, SABR_SET_I_SPOT, SABR_SET_I_TEXP, cp=1)
+    assert prices.shape == strikes.shape
+    assert np.all(prices > 0)
+
+
+def test_heston_positive_price():
+    """Spot check: Heston ATM call is positive and finite."""
+    m = pf.HestonFinDiff(**HESTON_PARAMS)
+    m.set_num_params(n_asset=80, n_vol=40, n_time=80)
+    price = m.price(100.0, 100.0, HESTON_TEXP, cp=1)
+    assert np.isfinite(price)
+    assert price > 0


### PR DESCRIPTION
`gh` isn't available in this environment. You can open the PR directly in your browser — GitHub will pre-fill the form when you visit:

**https://github.com/PyFE/PyFENG/compare/main...adi**

Here's the suggested PR content to paste in:

---

**Title:** `Add 2D Douglas ADI finite-difference solver for SABR and Heston`

**Body:**
```
## Summary

- Introduces `SvFinDiffABC`, a generic 2D Douglas ADI finite-difference engine
  working in normalized forward space (F₀ = 1, r = q = 0 internally)
- Adds three concrete pricers: `SabrFinDiff`, `HestonFinDiff`, `HestonCevFinDiff`
- Adds `HestonCevParams` / `HestonCevABC` to `params.py` / `heston.py`
- Exports all three classes from `pyfeng/__init__.py`
- Benchmark tests against BENCHOP-SLV reference values (von Sydow et al. 2019)

## Design

Douglas scheme (θ = ½ → Crank–Nicolson accuracy):

    Y₀ = Vⁿ + dt (F₀+F₁+F₂) Vⁿ            (explicit predictor)
    (I − θ dt F₁) Y₁ = Y₀ − θ dt F₁ Vⁿ    (S-implicit corrector)
    (I − θ dt F₂) Vⁿ⁺¹ = Y₁ − θ dt F₂ Vⁿ  (v-implicit corrector)

New models plug in by subclassing `SvFinDiffABC` and implementing four methods:
`_get_v0`, `_grid_bounds`, `_coefficients`, `_apply_bdd_cond`.

## Test plan

- [ ] `test_sabr_adi_benchop[20/21]` — BENCHOP-SLV SABR Sets I & II (abs 3e-3)
- [ ] `test_heston_adi_benchop` — BENCHOP-SLV Heston Set I (abs 0.15)
- [ ] `test_sabr_put_call_parity` / `test_heston_put_call_parity` — C−P = S₀−K
- [ ] `test_sabr_array_strikes` — vectorized strikes, correct shape
- [ ] `test_degenerate_to_cev` — SABR + HestonCev → CEV when vov → 0
- [ ] `test_heston_positive_price` — ATM call finite and positive

## Credits

Adapted from the MATH5030 Group 16 project (`mafn-finite-difference`,
https://github.com/py2025/finite-difference).
```