### PR TITLE
Replace np.isscalar and ones_like(a+b) with broadcast-aware idioms

### DIFF
--- a/pyfeng/bsm.py
+++ b/pyfeng/bsm.py
@@ -302,7 +302,7 @@ class Bsm(BsmParams, OptAnalyticABC):
         p_min = bsm_model.price(strike_std, 1.0, texp, cp)
         bsm_model.sigma = np.inf
         p_max = bsm_model.price(strike_std, 1.0, texp, cp)
-        scalar_output = np.isscalar(p_min) and np.isscalar(price_std)
+        bcast = np.broadcast_shapes(np.shape(p_min), np.shape(price_std))
 
         # Exclude optoin price below intrinsic value or above max value (1 for call or k for put)
         # ind_solve can be scalar or array. scalar can be fine in np.abs(p_err[ind_solve])
@@ -350,8 +350,7 @@ class Bsm(BsmParams, OptAnalyticABC):
             _sigma,
         )
 
-        if scalar_output:
-            _sigma = _sigma.item()
+        _sigma = _sigma.reshape(bcast)
 
         if setval:
             self.sigma = _sigma

--- a/pyfeng/nsvh.py
+++ b/pyfeng/nsvh.py
@@ -314,7 +314,7 @@ class NsvhMc(NsvhABC):
         fwd, df, _ = self._fwd_df_divf(spot, texp)
         mc_path = self.mc_vol_price(texp)
         strike_std = strike - fwd
-        scalar_output = np.isscalar(strike_std)
+        scalar_output = np.ndim(strike_std) == 0
         cp *= np.ones_like(strike_std)
 
         price = np.array([np.mean(np.fmax(cp[k] * (mc_path[1] - strike_std[k]), 0)) for k in range(len(strike_std))])
@@ -386,10 +386,10 @@ class NsvhGaussQuad(NsvhABC):
 
         #### effective strike
         strike_eff = (self.vov/self.sigma) * (strike - fwd)
-        scalar_output = np.isscalar(strike_eff)
+        scalar_output = np.ndim(strike_eff) == 0
 
         strike_eff, cp = np.broadcast_arrays(np.atleast_1d(strike_eff), cp)
-        
+
         u_hat = (z_value + 0.5 * self.lam * vovn)  # column (z direction)
         exp_plus = np.exp(vovn * u_hat/2)
         z_star_cosh = (exp_plus**2 + 1/exp_plus**2)/2
@@ -441,7 +441,7 @@ class NsvhGaussQuad(NsvhABC):
 
         #### effective strike
         strike_eff = (self.vov / self.sigma) * (strike - fwd)
-        scalar_output = np.isscalar(strike_eff)
+        scalar_output = np.ndim(strike_eff) == 0
 
         strike_eff, cp = np.broadcast_arrays(np.atleast_1d(strike_eff), cp)
 

--- a/pyfeng/opt_abc.py
+++ b/pyfeng/opt_abc.py
@@ -105,17 +105,16 @@ class OptABC(abc.ABC):
         model.sigma = self.IMPVOL_MAXVOL
         p_max = model.price(kk, 1, texp, cp)
 
-        scalar_output = np.isscalar(price) and np.isscalar(p_min)
-        ones_like = np.ones_like(np.atleast_1d(price + p_min))
+        bcast = np.broadcast_shapes(np.shape(price), np.shape(p_min))
+        out_shape = np.broadcast_shapes((1,), bcast)  # atleast_1d anchor
 
-        sigma = np.empty(ones_like.shape).flatten()
-        sigma.fill(np.nan)
-        price_flat = (ones_like * price_std).flatten()
-        p_min = (ones_like * p_min).flatten()
-        p_max = (ones_like * p_max).flatten()
-        texp_flat = (ones_like * texp).flatten()
-        kk_flat = (ones_like * kk).flatten()
-        cp_flat = (ones_like * cp).flatten()
+        sigma = np.full(out_shape, np.nan).flatten()
+        price_flat = np.broadcast_to(price_std, out_shape).flatten()
+        p_min = np.broadcast_to(p_min, out_shape).flatten()
+        p_max = np.broadcast_to(p_max, out_shape).flatten()
+        texp_flat = np.broadcast_to(texp, out_shape).flatten()
+        kk_flat = np.broadcast_to(kk, out_shape).flatten()
+        cp_flat = np.broadcast_to(cp, out_shape).flatten()
 
         def iv_func(_sigma):
             model.sigma = _sigma
@@ -142,10 +141,7 @@ class OptABC(abc.ABC):
                     warnings.warn(warn_msg, Warning)
             """
 
-        if scalar_output:
-            sigma = sigma[0]
-        else:
-            sigma = sigma.reshape(ones_like.shape)
+        sigma = sigma.reshape(bcast)
         if setval:
             self.sigma = sigma
         return sigma

--- a/pyfeng/sabr.py
+++ b/pyfeng/sabr.py
@@ -610,7 +610,7 @@ class SabrChoiWu2021P(SabrChoiWu2021H, MassZeroABC):
         kk = strike / fwd  # standardized strike
 
         # explicitly make np.array even if args are all scalar or list
-        scalar_output = np.isscalar(kk)
+        scalar_output = np.ndim(kk) == 0
         kk = np.atleast_1d(kk)
 
         ## Eq 32 (leading order)

--- a/pyfeng/sv_abc.py
+++ b/pyfeng/sv_abc.py
@@ -125,7 +125,7 @@ class CondMcBsmABC(OptABC):
     def price(self, strike, spot, texp, cp=1):
 
         kk = strike / spot
-        scalar_output = np.isscalar(kk)
+        scalar_output = np.ndim(kk) == 0
         kk = np.atleast_1d(kk)
         cp = np.atleast_1d(cp)
 
@@ -159,7 +159,7 @@ class CondMcBsmABC(OptABC):
         Returns:
             variance option price
         """
-        scalar_output = np.isscalar(strike)
+        scalar_output = np.ndim(strike) == 0
         strike = np.atleast_1d(strike)
         p = np.zeros_like(strike)
         var = self.return_var_realized(texp)
@@ -230,7 +230,7 @@ class SvMixtureABC(OptABC):
     def price(self, strike, spot, texp, cp=1):
 
         kk = strike / spot
-        scalar_output = np.isscalar(kk)
+        scalar_output = np.ndim(kk) == 0
         kk = np.atleast_1d(kk)
 
         spot_cond, sigma_cond, ww = self.cond_spot_sigma(texp)

--- a/pyfeng/sv_cos.py
+++ b/pyfeng/sv_cos.py
@@ -363,7 +363,7 @@ class CosABC(OptABC):
         Raises:
             ValueError: if ``pricing_formula`` is not recognised.
         """
-        scalar_out = np.isscalar(strike) and np.isscalar(cp)
+        scalar_out = np.ndim(strike) == 0 and np.ndim(cp) == 0
 
         if self.pricing_formula == 'lefloch':
             result = np.atleast_1d(self._price_lefloch(strike, spot, texp, cp))
@@ -690,7 +690,7 @@ class HestonCos(HestonABC, CosABC):
             if kurtosis_ratio > self.HIGH_KURTOSIS_RATIO:
                 half = self._resolve_L(texp) * float(np.sqrt(abs(c2)))
                 trunc = (float(c1) - half, float(c1) + half)
-                scalar_out = np.isscalar(strike) and np.isscalar(cp)
+                scalar_out = np.ndim(strike) == 0 and np.ndim(cp) == 0
                 result = np.atleast_1d(
                     self._price_lefloch(strike, spot, texp, cp, trunc_range=trunc)
                 )
@@ -705,7 +705,7 @@ class HestonCos(HestonABC, CosABC):
             return CosABC.price(self, strike, spot, texp, cp=cp)
 
         fwd, df, _ = self._fwd_df_divf(spot, texp)
-        scalar_out = np.isscalar(strike) and np.isscalar(cp)
+        scalar_out = np.ndim(strike) == 0 and np.ndim(cp) == 0
 
         a_arr, b_arr = self._integration_range(strike, spot, texp)
         half = self._resolve_L(texp) * self._sigma_h()

--- a/pyfeng/util.py
+++ b/pyfeng/util.py
@@ -120,7 +120,7 @@ class MathFuncs:
         """
         if not np.all(x > -1.0):
             raise ValueError("x must be greater than -1.0.")
-        rv = np.ones_like(x + a, dtype=float)
+        rv = np.ones(np.broadcast_shapes(np.shape(x), np.shape(a)), dtype=float)
         np.divide(np.expm1(a * np.log1p(x)), a * x, out=rv, where=(x != 0.0) & (a != 0.0))
         np.divide(np.log1p(x), x, out=rv, where=(x != 0.0) & (a == 0.0))
         return rv


### PR DESCRIPTION
- util.py: ones_like(x + a) → np.ones(np.broadcast_shapes(...))
- opt_abc.py: scalar_output + ones_like broadcast pattern → bcast/out_shape with np.broadcast_to; sigma.reshape(bcast) eliminates if/else
- bsm.py: same scalar_output + .item() pattern → bcast + _sigma.reshape(bcast)
- sv_abc.py, sabr.py, nsvh.py, sv_cos.py: np.isscalar(x) → np.ndim(x) == 0

np.ndim(x) == 0 correctly handles 0-d numpy arrays which np.isscalar misses. np.broadcast_shapes avoids allocating a temporary array just to read its shape.