### PR TITLE
Refactor numerical params: configure() API, per-instance RNG, BsmNdMc cleanup

### DIFF
--- a/pyfeng/cev.py
+++ b/pyfeng/cev.py
@@ -1,6 +1,7 @@
 import scipy.stats as spst
 import scipy.special as spsp
 import numpy as np
+from dataclasses import dataclass, field
 from .opt_abc import OptABC, OptAnalyticABC, MassZeroABC
 from . import sv_abc as sv
 from .params import CevParams
@@ -292,6 +293,7 @@ class Cev(CevParams, OptAnalyticABC, MassZeroABC):
         return -theta
 
 
+@dataclass
 class CevMc(CevParams, OptABC):
     """
     Constant Elasticity of Variance (CEV) model with exact Monte-Carlo method (Kang, 2014)
@@ -303,7 +305,7 @@ class CevMc(CevParams, OptABC):
         >>> import numpy as np
         >>> import pyfeng as pf
         >>> m = pf.CevMc(sigma=0.2*10, beta=0.5, intr=0.05, divr=0.1)
-        >>> m.set_num_params(n_path=160000, dt=None, rn_seed=123456)
+        >>> m.configure(n_path=160000, dt=None, rn_seed=123456)
         >>> m.price(np.arange(80, 121, 10), spot=100, texp=1.2)
         array([16.03769545,  9.88906886,  5.51705317,  2.78576033,  1.27297844])
 
@@ -311,15 +313,24 @@ class CevMc(CevParams, OptABC):
             - Kang C (2014) Simulation of the Shifted Poisson Distribution with an Application to the CEV Model. Management Science and Financial Engineering 20:27–32. https://doi.org/10.7737/MSFE.2014.20.1.027
     """
 
-    dt = 0.05
-    n_path = 10000
-    rn_seed = None
-    rng = np.random.default_rng(None)
-    correct_fwd = False
+    n_path:  int   = field(default=10000, kw_only=True, metadata={'kind': 'numerical'})
+    dt:      float = field(default=0.05,  kw_only=True, metadata={'kind': 'numerical'})
+    rn_seed: int   = field(default=None,  kw_only=True, metadata={'kind': 'numerical'})
+    correct_fwd: bool = field(default=False, kw_only=True, metadata={'kind': 'numerical'})
 
     tobs = sv.CondMcBsmABC.tobs
 
-    def set_num_params(self, n_path=10000, dt=0.25, rn_seed=None):
+    def __post_init__(self):
+        super().__post_init__()
+        seed_seq = np.random.SeedSequence(self.rn_seed)
+        self.rngs = [np.random.default_rng(s) for s in seed_seq.spawn(7)]
+        self.result = {}
+
+    @property
+    def rng(self):
+        return self.rngs[0]
+
+    def configure(self, n_path=None, dt=None, rn_seed=None):
         """
         Set MC parameters
 
@@ -328,10 +339,16 @@ class CevMc(CevParams, OptABC):
             dt: time step for Euler/Milstein steps
             rn_seed: random number seed
         """
-        self.n_path = int(n_path)
-        self.dt = dt
-        self.rn_seed = rn_seed
-        self.rng = np.random.default_rng(rn_seed)
+        if n_path is not None:
+            self.n_path = int(n_path)
+        if dt is not None:
+            self.dt = dt
+        if rn_seed is not None:
+            self.rn_seed = rn_seed
+        self.__post_init__()
+        return self
+
+    set_num_params = configure
 
     def price_step(self, spot, dt):
         """
@@ -354,7 +371,7 @@ class CevMc(CevParams, OptABC):
 
         var = (betac * self.sigma)**2 * dt * spsp.exprel(2*(self.intr-self.divr)*betac*dt)
         z0 = np.power(s_t[nz_idx], 2*betac) / var
-        rv_gam = 2 * self.rng.standard_gamma(1/(2*betac), size=len(z0))
+        rv_gam = 2 * self.rngs[0].standard_gamma(1/(2*betac), size=len(z0))
         pois_lam = (z0 - rv_gam) / 2
 
         # index for negative poisson value so that s_t becomes zero in this step
@@ -366,7 +383,7 @@ class CevMc(CevParams, OptABC):
             nz_idx[tmp_idx] = False
             s_t[~nz_idx] = 0.0
 
-        zt = 2 * self.rng.standard_gamma(self.rng.poisson(pois_lam) + 1)
+        zt = 2 * self.rngs[0].standard_gamma(self.rngs[0].poisson(pois_lam) + 1)
         s_t[nz_idx] = np.power(var * zt, 1/(2*betac))
         return s_t
 

--- a/pyfeng/cev.py
+++ b/pyfeng/cev.py
@@ -348,7 +348,6 @@ class CevMc(CevParams, OptABC):
         self.__post_init__()
         return self
 
-    set_num_params = configure
 
     def price_step(self, spot, dt):
         """

--- a/pyfeng/garch.py
+++ b/pyfeng/garch.py
@@ -1,6 +1,7 @@
 import warnings
 import numpy as np
 import scipy.special as spsp
+from dataclasses import dataclass, field
 from .sv_abc import CondMcBsmABC
 from .opt_abc import OptABC
 from . import bsm
@@ -81,15 +82,19 @@ class GarchUncorrBaroneAdesi2004(GarchParams, OptABC):
         return price
 
 
+@dataclass
 class GarchMcTimeDisc(GarchParams, CondMcBsmABC):
     """
     Garch model with conditional Monte-Carlo simulation
     The SDE of SV is: dv_t = mr * (theta - v_t) dt + vov * v_t dB_T
     """
 
-    scheme = 1  #
+    scheme: int = field(default=1, kw_only=True, metadata={'kind': 'numerical'})
 
-    def set_num_params(self, n_path=10000, dt=0.05, rn_seed=None, antithetic=True, scheme=1):
+    def __post_init__(self):
+        super().__post_init__()
+
+    def configure(self, n_path=None, dt=None, rn_seed=None, antithetic=None, scheme=None):
         """
         Set MC parameters
 
@@ -103,8 +108,10 @@ class GarchMcTimeDisc(GarchParams, CondMcBsmABC):
         References:
             - Andersen L (2008) Simple and efficient simulation of the Heston stochastic volatility model. Journal of Computational Finance 11:1–42. https://doi.org/10.21314/JCF.2008.189
         """
-        super().set_num_params(n_path, dt, rn_seed, antithetic)
-        self.scheme = scheme
+        super().configure(n_path, dt, rn_seed, antithetic)
+        if scheme is not None:
+            self.scheme = scheme
+        return self
 
     def vol_step_euler(self, dt, var_0, milstein=True):
         """

--- a/pyfeng/heston_mc.py
+++ b/pyfeng/heston_mc.py
@@ -1,10 +1,12 @@
 import abc
+from dataclasses import dataclass
 import warnings
 import numpy as np
 import scipy.stats as spst
 import scipy.interpolate as spinterp
 from scipy import special as spsp
 import functools
+from dataclasses import dataclass, field
 from .sv_abc import CondMcBsmABC
 from .heston import HestonABC
 from .mgf2mom import Mgf2Mom
@@ -18,6 +20,7 @@ from .mgf2mom import Mgf2Mom
 # 5: asset return
 
 
+@dataclass
 class HestonMcABC(HestonABC, CondMcBsmABC):
     scheme = None
     correct_fwd = False
@@ -37,9 +40,9 @@ class HestonMcABC(HestonABC, CondMcBsmABC):
         if dist.lower() == 'ig':
             # mu and lambda defined in https://en.wikipedia.org/wiki/Inverse_Gaussian_distribution
             # RNG.wald takes the same parameters
-            avgvar = self.rng_spawn[2].wald(mean=mean, scale=mean / var_scaled)
+            avgvar = self.rngs[2].wald(mean=mean, scale=mean / var_scaled)
         elif dist.lower() == 'ga':
-            avgvar = var_scaled * mean * self.rng_spawn[2].standard_gamma(shape=1 / var_scaled)
+            avgvar = var_scaled * mean * self.rngs[2].standard_gamma(shape=1 / var_scaled)
         elif dist.lower() == 'ln':
             scale = np.sqrt(np.log1p(var_scaled))
             avgvar = mean * np.exp(scale * (self.rv_normal(spawn=2) - scale / 2))
@@ -351,6 +354,7 @@ class HestonMcABC(HestonABC, CondMcBsmABC):
         return m_total, v_total / m_total**2
 
 
+@dataclass
 class HestonMcGlassermanKim2011(HestonMcABC):
     """
     Exact simulation using the gamma series based on Glasserman & Kim (2011)
@@ -364,7 +368,7 @@ class HestonMcGlassermanKim2011(HestonMcABC):
         >>> strike = np.array([60, 70, 100, 140])
         >>> sigma, vov, mr, rho, texp, spot = 0.04, 1, 0.5, -0.9, 10, 100
         >>> m = pf.HestonMcGlassermanKim2011(sigma, vov=vov, mr=mr, rho=rho)
-        >>> m.set_num_params(n_path=1e5, kk=4, rn_seed=123456)
+        >>> m.configure(n_path=1e5, kk=4, rn_seed=123456)
         >>> m.price(strike, spot, texp)
         >>> # true price: 44.32997507, 35.8497697, 13.08467014, 0.29577444
         array([44.35153812, 35.86029054, 13.17026256,  0.29550527])
@@ -372,11 +376,13 @@ class HestonMcGlassermanKim2011(HestonMcABC):
     """
 
     dist = 'ga'  # distribution for the truncated series
-    kk = 1  # K for series truncation.
     tabulate_x2_z = False
+    kk: int = field(default=1, kw_only=True, metadata={'kind': 'numerical'})
 
+    def __post_init__(self):
+        super().__post_init__()
 
-    def set_num_params(self, n_path=10000, dt=None, rn_seed=None, antithetic=True, kk=1):
+    def configure(self, n_path=None, dt=None, rn_seed=None, antithetic=None, kk=None):
         """
         Set MC parameters
 
@@ -387,8 +393,10 @@ class HestonMcGlassermanKim2011(HestonMcABC):
             kk: truncation index
 
         """
-        super().set_num_params(n_path, dt, rn_seed, antithetic)
-        self.kk = kk
+        super().configure(n_path, dt, rn_seed, antithetic)
+        if kk is not None:
+            self.kk = kk
+        return self
 
     def cond_avgvar_mgf(self, aa, dt, var_0, var_t):
         """
@@ -556,14 +564,14 @@ class HestonMcGlassermanKim2011(HestonMcABC):
             x1/dt
         """
         gamma_n, lambda_n = self.gamma_lambda(dt, self.kk)
-        pois = self.rng_spawn[3].poisson(lam=(var_0 + var_t) * lambda_n[:, None])  # (kk, n_path)
+        pois = self.rngs[3].poisson(lam=(var_0 + var_t) * lambda_n[:, None])  # (kk, n_path)
 
-        rv_exp_sum = self.rng_spawn[2].standard_gamma(shape=pois)
+        rv_exp_sum = self.rngs[2].standard_gamma(shape=pois)
         x1 = np.sum(rv_exp_sum / gamma_n[:, None], axis=0)
 
         trunc_m, trunc_vs = self.x1star_avgvar_mv(dt, kk=self.kk)
         # we could call self.draw_from_mv, but we don't to make the code simple.
-        x1 += trunc_vs * trunc_m * self.rng_spawn[2].standard_gamma((var_0 + var_t) / trunc_vs)
+        x1 += trunc_vs * trunc_m * self.rngs[2].standard_gamma((var_0 + var_t) / trunc_vs)
         return x1
 
     def x2_cdf_points_aw(self, dt, shape):
@@ -656,20 +664,20 @@ class HestonMcGlassermanKim2011(HestonMcABC):
 
         gamma_n, _ = self.gamma_lambda(dt, kk=self.kk)
 
-        gamma_rv = self.rng_spawn[2].standard_gamma(shape, size=(self.kk, size))
+        gamma_rv = self.rngs[2].standard_gamma(shape, size=(self.kk, size))
         x2 = np.sum(gamma_rv / gamma_n[:, None], axis=0)
 
         # remainder (truncated) terms
         trunc_m, trunc_vs = self.x2star_avgvar_mv(dt, self.kk)
         # we could call self.draw_from_mv, but we don't to make the code simple.
         # trunc_vs * trunc_m (scale) and shape / trunc_vs are scalar values
-        x2 += trunc_vs * trunc_m * self.rng_spawn[2].standard_gamma(shape / trunc_vs, size=size)
+        x2 += trunc_vs * trunc_m * self.rngs[2].standard_gamma(shape / trunc_vs, size=size)
 
         return x2
 
     def cond_states_step(self, dt, var_0):
 
-        var_t = self.cir.draw_ncx2(dt, var_0, self.rng_spawn[0])
+        var_t = self.cir.draw_ncx2(dt, var_0, self.rngs[0])
         eta = self.draw_eta(dt, var_0, var_t)
 
         # sample int_var(integrated variance): Gamma expansion / transform inversion
@@ -678,10 +686,10 @@ class HestonMcGlassermanKim2011(HestonMcABC):
         avgvar = self.draw_x1(dt, var_0, var_t)
         if self.tabulate_x2_z:
             interp_obj = self.x2_icdf_interp(dt, self.cir.chi_dim() / 2, k1=self.params_hash())
-            avgvar += interp_obj(self.rng_spawn[2].uniform(size=self.n_path))
+            avgvar += interp_obj(self.rngs[2].uniform(size=self.n_path))
 
             interp_obj = self.x2_icdf_interp(dt, 2, k1=self.params_hash())
-            zz = interp_obj(self.rng_spawn[2].uniform(size=eta.sum()))
+            zz = interp_obj(self.rngs[2].uniform(size=eta.sum()))
         else:
             avgvar += self.draw_x2(dt, self.cir.chi_dim() / 2, size=self.n_path)
             zz = self.draw_x2(dt, 2.0, size=eta.sum())
@@ -700,6 +708,7 @@ class HestonMcGlassermanKim2011(HestonMcABC):
         return var_t, avgvar, {}
 
 
+@dataclass
 class HestonMcAndersen2008(HestonMcABC):
     """
     Heston model with conditional Monte-Carlo simulation
@@ -784,15 +793,15 @@ class HestonMcAndersen2008(HestonMcABC):
             milstein = (self.scheme == 1)
             for i in range(n_dt):
                 # Euler (or Milstein) scheme
-                var_t = self.cir.draw_euler(dt[i], var_t, self.rng_spawn[0], milstein=milstein)
+                var_t = self.cir.draw_euler(dt[i], var_t, self.rngs[0], milstein=milstein)
                 var_path[i + 1, :] = var_t
         elif self.scheme == 2:
             for i in range(n_dt):
-                var_t = self.cir.draw_ncx2(dt[i], var_t, self.rng_spawn[0])
+                var_t = self.cir.draw_ncx2(dt[i], var_t, self.rngs[0])
                 var_path[i + 1, :] = var_t
         elif self.scheme == 3:
             for i in range(n_dt):
-                var_t, _ = self.cir.draw_pois_gamma(dt[i], var_t, self.rng_spawn[0], self.rng_spawn[1])
+                var_t, _ = self.cir.draw_pois_gamma(dt[i], var_t, self.rngs[0], self.rngs[1])
                 var_path[i + 1, :] = var_t
         elif self.scheme == 4:
             for i in range(n_dt):
@@ -808,11 +817,11 @@ class HestonMcAndersen2008(HestonMcABC):
         extra = {}
         if self.scheme < 2:
             milstein = (self.scheme == 1)
-            var_t = self.cir.draw_euler(dt, var_0, self.rng_spawn[0], milstein=milstein)
+            var_t = self.cir.draw_euler(dt, var_0, self.rngs[0], milstein=milstein)
         elif self.scheme == 2:
-            var_t = self.cir.draw_ncx2(dt, var_0, self.rng_spawn[0])
+            var_t = self.cir.draw_ncx2(dt, var_0, self.rngs[0])
         elif self.scheme == 3:
-            var_t, _ = self.cir.draw_pois_gamma(dt, var_0, self.rng_spawn[0], self.rng_spawn[1])
+            var_t, _ = self.cir.draw_pois_gamma(dt, var_0, self.rngs[0], self.rngs[1])
         elif self.scheme == 4:
             var_t, m_corr = self.var_step_qe(dt, var_0)
             extra = {'qe_m_corr': m_corr}
@@ -825,6 +834,7 @@ class HestonMcAndersen2008(HestonMcABC):
         return var_t, avgvar, extra
 
 
+@dataclass
 class HestonMcChoiKwok2023PoisTd(HestonMcABC):
     """
     Heston simulation scheme Poisson-conditioned time discretization quadrature
@@ -856,14 +866,14 @@ class HestonMcChoiKwok2023PoisTd(HestonMcABC):
         var_t = np.full(self.n_path, var_0)
 
         for i in range(n_dt):
-            var_t, _ = self.cir.draw_pois_gamma(dt[i], var_t, self.rng_spawn[0], self.rng_spawn[1])
+            var_t, _ = self.cir.draw_pois_gamma(dt[i], var_t, self.rngs[0], self.rngs[1])
             var_path[i + 1, :] = var_t
 
         return var_path
 
     def cond_states_step(self, dt, var_0):
 
-        var_t, pois = self.cir.draw_pois_gamma(dt, var_0, self.rng_spawn[0], self.rng_spawn[1])
+        var_t, pois = self.cir.draw_pois_gamma(dt, var_0, self.rngs[0], self.rngs[1])
         avgvar_m, avgvar_vs = self.cond_avgvar_mv(dt, var_0, var_t, pois=pois, kk=0)
         extra = {'pois_avgvar_v': avgvar_vs * avgvar_m**2}
 
@@ -896,6 +906,7 @@ class HestonMcChoiKwok2023PoisTd(HestonMcABC):
     #     return unex / var
 
 
+@dataclass
 class HestonMcTseWan2013(HestonMcABC):
     """
     Almost exact MC for Heston model.
@@ -917,13 +928,14 @@ class HestonMcTseWan2013(HestonMcABC):
     dist = 'ig'  # can override with 'ga' 'ln' 'n'
 
     def cond_states_step(self, dt, var_0):
-        var_t = self.cir.draw_ncx2(dt, var_0, self.rng_spawn[0])
+        var_t = self.cir.draw_ncx2(dt, var_0, self.rngs[0])
         avgvar_m, avgvar_vs = self.cond_avgvar_mv(dt, var_0, var_t, pois=None, kk=0)
         avgvar = self.draw_from_mv(avgvar_m, avgvar_vs, dist=self.dist)
 
         return var_t, avgvar, {}
 
 
+@dataclass
 class HestonMcChoiKwok2023PoisGe(HestonMcABC):
     """
     Poisson-conditioned exact simulation scheme from Choi & Kwok (2023).
@@ -939,7 +951,7 @@ class HestonMcChoiKwok2023PoisGe(HestonMcABC):
         >>> strike = np.array([60, 70, 100, 140])
         >>> sigma, vov, mr, rho, texp, spot = 0.04, 1, 0.5, -0.9, 10, 100
         >>> m = pf.HestonMcChoiKwok2023PoisGe(sigma, vov=vov, mr=mr, rho=rho)
-        >>> m.set_num_params(n_path=1e5, kk=4, rn_seed=123456)
+        >>> m.configure(n_path=1e5, kk=4, rn_seed=123456)
         >>> m.price(strike, spot, texp)
         >>> # true price: 44.32997507, 35.8497697, 13.08467014, 0.29577444
         array([44.35753578, 35.8767866 , 13.12277647,  0.29461611])
@@ -947,9 +959,12 @@ class HestonMcChoiKwok2023PoisGe(HestonMcABC):
     """
 
     dist = 'ig'  # distribution for series truncation
-    kk = 1  # K for series truncation.
+    kk: int = field(default=1, kw_only=True, metadata={'kind': 'numerical'})
 
-    def set_num_params(self, n_path=10000, dt=None, rn_seed=None, antithetic=True, kk=1):
+    def __post_init__(self):
+        super().__post_init__()
+
+    def configure(self, n_path=None, dt=None, rn_seed=None, antithetic=None, kk=None):
         """
         Set MC parameters
 
@@ -959,8 +974,10 @@ class HestonMcChoiKwok2023PoisGe(HestonMcABC):
             rn_seed: random number seed
             kk: truncation index
         """
-        super().set_num_params(n_path, dt, rn_seed, antithetic)
-        self.kk = kk
+        super().configure(n_path, dt, rn_seed, antithetic)
+        if kk is not None:
+            self.kk = kk
+        return self
 
     def draw_x123(self, dt, var_sum, shape_sum):
         """
@@ -977,8 +994,8 @@ class HestonMcChoiKwok2023PoisGe(HestonMcABC):
         gamma_n, lambda_n = self.gamma_lambda(dt, kk=self.kk)
 
         if self.kk > 0:
-            pois = self.rng_spawn[3].poisson(lam=var_sum * lambda_n[:, None])
-            x123 = np.sum(self.rng_spawn[2].standard_gamma(shape=pois + shape_sum) / gamma_n[:, None], axis=0)
+            pois = self.rngs[3].poisson(lam=var_sum * lambda_n[:, None])
+            x123 = np.sum(self.rngs[2].standard_gamma(shape=pois + shape_sum) / gamma_n[:, None], axis=0)
         else:
             x123 = np.zeros_like(var_sum)
 
@@ -992,7 +1009,7 @@ class HestonMcChoiKwok2023PoisGe(HestonMcABC):
 
     def cond_states_step(self, dt, var_0):
 
-        var_t, pois = self.cir.draw_pois_gamma(dt, var_0, self.rng_spawn[0], self.rng_spawn[1])
+        var_t, pois = self.cir.draw_pois_gamma(dt, var_0, self.rngs[0], self.rngs[1])
         shape = 0.5*self.cir.chi_dim() + 2*pois
 
         # self.draw_x123 returns the average by dt. Need to convert to the int variance by multiplying texp

--- a/pyfeng/heston_mc.py
+++ b/pyfeng/heston_mc.py
@@ -725,8 +725,7 @@ class HestonMcAndersen2008(HestonMcABC):
         >>> import pyfeng as pf
         >>> strike = np.array([60, 70, 100, 140])
         >>> sigma, vov, mr, rho, texp, spot = 0.04, 1, 0.5, -0.9, 10, 100
-        >>> m = pf.HestonMcAndersen2008(sigma, vov=vov, mr=mr, rho=rho)
-        >>> m.set_num_params(n_path=1e5, dt=1/8, rn_seed=123456)
+        >>> m = pf.HestonMcAndersen2008(sigma, vov=vov, mr=mr, rho=rho).configure(n_path=1e5, dt=1/8, rn_seed=123456)
         >>> m.price(strike, spot, texp)
         >>> # true price: 44.32997507, 35.8497697, 13.08467014, 0.29577444
         array([44.28356337, 35.80059515, 13.05391402,  0.29848727])
@@ -848,8 +847,7 @@ class HestonMcChoiKwok2023PoisTd(HestonMcABC):
         >>> strike = np.array([60, 70, 100, 140])
         >>> spot = 100
         >>> sigma, vov, mr, rho, texp = 0.04, 1, 0.5, -0.9, 10
-        >>> m = pf.HestonMcChoiKwok2023PoisTd(sigma, vov=vov, mr=mr, rho=rho)
-        >>> m.set_num_params(n_path=1e5, dt=1/8, rn_seed=123456)
+        >>> m = pf.HestonMcChoiKwok2023PoisTd(sigma, vov=vov, mr=mr, rho=rho).configure(n_path=1e5, dt=1/8, rn_seed=123456)
         >>> m.price(strike, spot, texp)
         >>> # true price: 44.32997507, 35.8497697, 13.08467014, 0.29577444
         array([44.36484309, 35.87571609, 13.08606262,  0.29620234])
@@ -919,8 +917,7 @@ class HestonMcTseWan2013(HestonMcABC):
         >>> strike = np.array([60, 100, 140])
         >>> spot = 100
         >>> sigma, vov, mr, rho, texp = 0.04, 1, 0.5, -0.9, 10
-        >>> m = pfex.HestonMcTseWan2013(sigma, vov=vov, mr=mr, rho=rho)
-        >>> m.set_num_params(n_path=1e4, rn_seed=123456)
+        >>> m = pfex.HestonMcTseWan2013(sigma, vov=vov, mr=mr, rho=rho).configure(n_path=1e4, rn_seed=123456)
         >>> m.price(strike, spot, texp)
         >>> # true price: 44.330, 13.085, 0.296
         array([12.08981758,  0.33379748, 42.28798189])  # not close so far

--- a/pyfeng/heston_rough_mc.py
+++ b/pyfeng/heston_rough_mc.py
@@ -83,7 +83,6 @@ class RoughHestonMcABC(RoughHestonABC, CondMcBsmABC):
         self.tgrid = np.linspace(0, texp, self.n_ts + 1)
         return self
 
-    set_num_params = configure
 
 
 @dataclass

--- a/pyfeng/heston_rough_mc.py
+++ b/pyfeng/heston_rough_mc.py
@@ -9,10 +9,12 @@ import abc
 import numpy as np
 import scipy.special as spsp
 import scipy.integrate as spint
+from dataclasses import dataclass, field
 from .sv_abc import CondMcBsmABC
 from .heston_rough import RoughHestonABC
 
 
+@dataclass
 class RoughHestonMcABC(RoughHestonABC, CondMcBsmABC):
     """
     Abstract base class for Monte Carlo simulation of the rough Heston model.
@@ -34,21 +36,27 @@ class RoughHestonMcABC(RoughHestonABC, CondMcBsmABC):
         alpha  → α    (roughness exponent; negative for rough paths)
     """
 
-    def __init__(self, sigma, vov, rho, mr, theta, alpha, intr=0.0, divr=0.0) -> None:
-        """
-        Args:
-            sigma: initial variance V_0 > 0
-            vov:   vol-of-vol κε > 0 (product of mean-reversion speed and vol-of-vol ratio)
-            rho:   correlation between asset and variance Brownian motions, ρ ∈ (-1, 1)
-            mr:    mean-reversion speed κ > 0
-            theta: long-run variance θ > 0
-            alpha: roughness exponent α = H - 1/2 ∈ (-1/2, 0); H < 1/2 gives rough paths
-            intr:  risk-free interest rate r (annualised, default 0)
-            divr:  continuous dividend yield q (annualised, default 0)
-        """
-        super().__init__(sigma, vov, rho, mr, theta, alpha, intr=intr, divr=divr)
+    n_ts:       int  = field(default=1000,  kw_only=True, metadata={'kind': 'numerical'})
+    n_path:     int  = field(default=10000, kw_only=True, metadata={'kind': 'numerical'})
+    rn_seed:    int  = field(default=None,  kw_only=True, metadata={'kind': 'numerical'})
+    antithetic: bool = field(default=True,  kw_only=True, metadata={'kind': 'numerical'})
 
-    def set_num_params(self, texp, n_path=10000, n_ts=1000, rn_seed=None, antithetic=True):
+    def __post_init__(self):
+        super().__post_init__()
+        # Precomputed Gamma-function values used repeatedly in Eqs. (8), (17)–(20)
+        self._gamma_a   = spsp.gamma(self.alpha)
+        self._gamma_1ma = spsp.gamma(1 - self.alpha)   # Γ(1-α)
+        self._gamma_2ma = spsp.gamma(2 - self.alpha)   # Γ(2-α) = (1-α)·Γ(1-α)
+        self._gamma_1pa = spsp.gamma(1 + self.alpha)   # Γ(1+α)
+        seed_seq = np.random.SeedSequence(self.rn_seed)
+        self.rngs = [np.random.default_rng(s) for s in seed_seq.spawn(7)]
+        self.result = {}
+
+    @property
+    def rng(self):
+        return self.rngs[0]
+
+    def configure(self, texp, n_ts=None, n_path=None, rn_seed=None, antithetic=None):
         """
         Set numerical simulation parameters and precompute frequently used constants.
 
@@ -59,20 +67,26 @@ class RoughHestonMcABC(RoughHestonABC, CondMcBsmABC):
             rn_seed: random seed for reproducibility (default None)
             antithetic: use antithetic variates for variance reduction (default True)
         """
-        super().set_num_params(n_path, n_ts, rn_seed, antithetic)
+        if n_ts is not None:
+            self.n_ts = int(n_ts)
+        if n_path is not None:
+            self.n_path = int(n_path)
+        if rn_seed is not None:
+            self.rn_seed = rn_seed
+        if antithetic is not None:
+            self.antithetic = antithetic
+
+        self.__post_init__()
 
         self.texp = texp
-        self.n_ts = int(n_ts)
-        self.dt = self.texp / self.n_ts          # τ = T/N
-        self.tgrid = np.linspace(0, self.texp, self.n_ts + 1)
+        self.dt = texp / self.n_ts               # τ = T/N
+        self.tgrid = np.linspace(0, texp, self.n_ts + 1)
+        return self
 
-        # Precomputed Gamma-function values used repeatedly in Eqs. (8), (17)–(20)
-        self._gamma_a = spsp.gamma(self.alpha)
-        self._gamma_1ma = spsp.gamma(1 - self.alpha)   # Γ(1-α)
-        self._gamma_2ma = spsp.gamma(2 - self.alpha)   # Γ(2-α) = (1-α)·Γ(1-α)
-        self._gamma_1pa = spsp.gamma(1 + self.alpha)   # Γ(1+α)
+    set_num_params = configure
 
 
+@dataclass
 class RoughHestonMcMaWu2022(RoughHestonMcABC):
     """
     Monte Carlo simulation of the rough Heston model using the fast algorithm of Ma & Wu (2022).
@@ -105,7 +119,7 @@ class RoughHestonMcMaWu2022(RoughHestonMcABC):
     """
 
     def __init__(self, sigma, vov, rho, mr, theta, alpha, intr=0.0, divr=0.0) -> None:
-        super().__init__(sigma, vov, rho, mr, theta, alpha, intr, divr)
+        super().__init__(sigma, vov, rho, mr, theta, alpha, intr=intr, divr=divr)
 
     def f(self, V_s):
         """
@@ -151,8 +165,8 @@ class RoughHestonMcMaWu2022(RoughHestonMcABC):
             Z_t1: shape (n_ts, n_path), i.i.d. N(0,1) increments for the variance BM B
             W_t:  shape (n_ts, n_path), correlated N(0,1) increments for the asset BM W
         """
-        Z_t1 = self.rng_spawn[0].normal(size=(self.n_ts, self.n_path))
-        W_t = self.rho * Z_t1 + np.sqrt(1 - self.rho**2) * self.rng_spawn[1].normal(size=(self.n_ts, self.n_path))
+        Z_t1 = self.rngs[0].normal(size=(self.n_ts, self.n_path))
+        W_t = self.rho * Z_t1 + np.sqrt(1 - self.rho**2) * self.rngs[1].normal(size=(self.n_ts, self.n_path))
         return Z_t1, W_t
     
     def term_1(self, t_n, t_k):

--- a/pyfeng/multiasset.py
+++ b/pyfeng/multiasset.py
@@ -3,6 +3,7 @@ import warnings
 
 import scipy.stats as spst
 import numpy as np
+from dataclasses import dataclass, field
 from .bsm import Bsm
 from .norm import Norm
 from .gamma import InvGam
@@ -557,6 +558,7 @@ class BsmBasketJsu(BsmBasketABC):
         return df * price
 
 
+@dataclass
 class BsmBasketChoi2018(BsmBasketABC):
     """
     Choi (2018)'s pricing method for Basket/Spread/Asian options
@@ -565,8 +567,8 @@ class BsmBasketChoi2018(BsmBasketABC):
         - Choi J (2018) Sum of all Black-Scholes-Merton models: An efficient pricing method for spread, basket, and Asian options. Journal of Futures Markets 38:627–644. https://doi.org/10.1002/fut.21909
     """
 
-    n_quad = None
-    lam = 4.0
+    n_quad: int   = field(default=None, kw_only=True, metadata={'kind': 'numerical'})
+    lam:    float = field(default=4.0,  kw_only=True, metadata={'kind': 'numerical'})
 
     @classmethod
     def init_lowerbound(cls, sigma, rho=None, cor_m=None, cov_m=None, weight=None, intr=0.0, divr=0.0, is_fwd=False):
@@ -574,9 +576,14 @@ class BsmBasketChoi2018(BsmBasketABC):
         m.n_quad = 0
         return m
 
-    def set_num_params(self, n_quad=None, lam=3.0):
-        self.n_quad = n_quad
-        self.lam = lam
+    def configure(self, n_quad=None, lam=None):
+        if n_quad is not None:
+            self.n_quad = n_quad
+        if lam is not None:
+            self.lam = lam
+        return self
+
+    set_num_params = configure
 
     @staticmethod
     def householder(vv0):

--- a/pyfeng/multiasset.py
+++ b/pyfeng/multiasset.py
@@ -583,7 +583,6 @@ class BsmBasketChoi2018(BsmBasketABC):
             self.lam = lam
         return self
 
-    set_num_params = configure
 
     @staticmethod
     def householder(vv0):

--- a/pyfeng/multiasset_mc.py
+++ b/pyfeng/multiasset_mc.py
@@ -1,24 +1,20 @@
 import numpy as np
 from .params import MaParams
-from .opt_abc import OptABC
 
 
-class BsmNdMc(MaParams, OptABC):
+class BsmNdMc(MaParams):
     """
     Monte-Carlo simulation of multiasset (N-d) BSM (geometric Brownian Motion)
 
     Examples:
         >>> import pyfeng as pf
-        >>> spot = np.ones(4)*100
-        >>> sigma = np.ones(4)*0.4
+        >>> spot = np.ones(4) * 100
+        >>> sigma = np.ones(4) * 0.4
         >>> texp = 5
-        >>> payoff = lambda x: np.fmax(np.mean(x,axis=1) - strike, 0) # Basket option
+        >>> payoff = lambda x: np.fmax(np.mean(x, axis=1) - strike, 0)  # Basket option
         >>> strikes = np.arange(80, 121, 10)
-        >>> m = pf.BsmNdMc(sigma, cor=0.5, rn_seed=1234)
-        >>> m.simulate(n_path=20000, tobs=[texp])
-        >>> p = []
-        >>> for strike in strikes:
-        >>>    p.append(m.price_european(spot, texp, payoff))
+        >>> m = pf.BsmNdMc(sigma, rho=0.5).configure(n_path=20000, rn_seed=1234).simulate([texp])
+        >>> p = [m.price_european(spot, texp, payoff) for strike in strikes]
         >>> np.array(p)
         array([36.31612946, 31.80861014, 27.91269315, 24.55319506, 21.62677625])
     """
@@ -26,20 +22,36 @@ class BsmNdMc(MaParams, OptABC):
     spot = np.ones(2)
     sigma = np.ones(2) * 0.1
 
-    # MC params
-    rn_seed = None
-    rng = None
-    antithetic = True
-
-    # tobs and path stored in the class
-    n_path = 0
-    path = tobs = None
-
     def __init__(self, sigma, rho=None, cor_m=None, cov_m=None, intr=0.0, divr=0.0, rn_seed=None, antithetic=True):
         self.rn_seed = rn_seed
         self.rng = np.random.default_rng(rn_seed)
         self.antithetic = antithetic
+        # per-instance simulation state (not class-level, to avoid shared-state bug)
+        self.n_path = 0
+        self.path = None
+        self.tobs = None
         super().__init__(sigma, rho=rho, cor_m=cor_m, cov_m=cov_m, intr=intr, divr=divr, is_fwd=False)
+
+    def configure(self, n_path=None, rn_seed=None, antithetic=None):
+        """
+        Set numerical simulation parameters.
+
+        Args:
+            n_path: number of MC paths
+            rn_seed: random seed (reseeds the RNG when provided)
+            antithetic: use antithetic variates (default True)
+
+        Returns:
+            self  (for method chaining)
+        """
+        if n_path is not None:
+            self.n_path = int(n_path)
+        if rn_seed is not None:
+            self.rn_seed = rn_seed
+            self.rng = np.random.default_rng(rn_seed)
+        if antithetic is not None:
+            self.antithetic = antithetic
+        return self
 
     def _bm_incr(self, tobs, n_path):
         """
@@ -50,15 +62,15 @@ class BsmNdMc(MaParams, OptABC):
             n_path: number of paths to simulate
 
         Returns:
-            price path (time, path, asset)
+            BM increments (time, path, asset)
         """
         dt = np.diff(np.atleast_1d(tobs), prepend=0)
         n_t = len(dt)
 
         n_path_gen = n_path // 2 if self.antithetic else n_path
 
-        # generate random number in the order of path, time, asset and transposed
-        # in this way, the same paths are generated when increasing n_path
+        # generate random numbers in (path, time, asset) order then transpose;
+        # this ensures the same paths are produced when n_path is increased
         bm_incr = self.rng.standard_normal((n_path_gen, n_t, self.n_asset)).transpose((1, 0, 2))
         np.multiply(bm_incr, np.sqrt(dt[:, None, None]), out=bm_incr)
         bm_incr = np.dot(bm_incr, self.chol_m.T)
@@ -69,59 +81,65 @@ class BsmNdMc(MaParams, OptABC):
 
         return bm_incr
 
-    def simulate(self, tobs, n_path, store=True):
+    def simulate(self, tobs, store=True):
         """
-        Simulate the price paths and store in the class.
-        The initial prices are normalized to 0 and spot should be multiplied later.
+        Build simulated price paths.
+
+        The number of paths is taken from ``self.n_path`` (set via
+        :meth:`configure`).  The initial price is normalised to 1; multiply
+        by ``spot`` when evaluating payoffs.
 
         Args:
-            tobs: array of observation times
-            n_path: number of paths to simulate
-            store: if True (default), store path, tobs, and n_path in the class
+            tobs: observation times (scalar or array)
+            store: if True (default), store path and tobs; return self.
+                   if False, return the path array without storing.
 
         Returns:
-            price path (time, path, asset) if store is False
-        """
+            self when store=True (for method chaining), or
+            path array (time, path, asset) when store=False.
 
-        # (n_t, n_path, n_asset) * (n_asset, n_asset)
+        Raises:
+            ValueError: if n_path has not been set via configure().
+        """
+        if not self.n_path:
+            raise ValueError("n_path is not set. Call configure(n_path=...) first.")
+
         tobs = np.atleast_1d(tobs)
-        path = self._bm_incr(tobs=tobs, n_path=n_path)
-        # Add drift and convexity
+        path = self._bm_incr(tobs=tobs, n_path=self.n_path)
+        # drift + convexity correction
         dt = np.diff(tobs, prepend=0)
         path += (self.intr - self.divr - 0.5 * self.sigma ** 2) * dt[:, None, None]
         np.cumsum(path, axis=0, out=path)
         np.exp(path, out=path)
 
         if store:
-            self.n_path = n_path
             self.path = path
             self.tobs = tobs
+            return self
         else:
             return path
 
     def price_european(self, spot, texp, payoff):
         """
-        The European price of that payoff at the expiry.
+        Price a European payoff using stored paths.
 
         Args:
             spot: array of spot prices
-            texp: time-to-expiry
-            payoff: payoff function applicable to the time-slice of price path
+            texp: time-to-expiry (must be one of the stored tobs)
+            payoff: function of the (path, asset) slice at texp
 
         Returns:
-            The MC price of the payoff
+            discounted MC price
         """
-        if self.n_path == 0:
-            raise ValueError("Simulated paths are not available. Run simulate() first.")
+        if self.path is None:
+            raise ValueError("No paths stored. Call simulate() first.")
 
-        # check if texp is in tobs
         ind, *_ = np.where(np.isclose(self.tobs, texp))
         if len(ind) == 0:
             raise ValueError(f"Stored tobs does not contain t={texp}")
 
         path = self.path[ind[0], ] * spot
-        price = np.exp(-self.intr * texp) * np.mean(payoff(path), axis=0)
-        return price
+        return np.exp(-self.intr * texp) * np.mean(payoff(path), axis=0)
 
 
 class NormNdMc(BsmNdMc):
@@ -130,64 +148,65 @@ class NormNdMc(BsmNdMc):
 
     Examples:
         >>> import pyfeng as pf
-        >>> spot = np.ones(4)*100
-        >>> sigma = np.ones(4)*0.4
+        >>> spot = np.ones(4) * 100
+        >>> sigma = np.ones(4) * 0.4
         >>> texp = 5
-        >>> payoff = lambda x: np.fmax(np.mean(x,axis=1) - strike, 0) # Basket option
+        >>> payoff = lambda x: np.fmax(np.mean(x, axis=1) - strike, 0)  # Basket option
         >>> strikes = np.arange(80, 121, 10)
-        >>> m = pf.NormNdMc(sigma*spot, cor=0.5, rn_seed=1234)
-        >>> m.simulate(tobs=[texp], n_path=20000)
-        >>> p = []
-        >>> for strike in strikes:
-        >>>    p.append(m.price_european(spot, texp, payoff))
+        >>> m = pf.NormNdMc(sigma * spot, rho=0.5).configure(n_path=20000, rn_seed=1234).simulate([texp])
+        >>> p = [m.price_european(spot, texp, payoff) for strike in strikes]
         >>> np.array(p)
         array([39.42304794, 33.60383167, 28.32667559, 23.60383167, 19.42304794])
     """
 
-    def simulate(self, tobs, n_path, store=True):
+    def simulate(self, tobs, store=True):
         """
-        Simulate the price paths and store in the class.
-        The initial prices are normalized to 0 and spot should be added later.
+        Build simulated price paths (arithmetic BM; add spot to get absolute prices).
 
         Args:
-            tobs: array of observation times
-            n_path: number of paths to simulate
-            store: if True (default), store path, tobs, and n_path in the class
+            tobs: observation times (scalar or array)
+            store: if True (default), store path and tobs; return self.
+                   if False, return the path array without storing.
 
         Returns:
-            price path (time, path, asset) if store is False
+            self when store=True (for method chaining), or
+            path array (time, path, asset) when store=False.
+
+        Raises:
+            ValueError: if n_path has not been set via configure().
         """
+        if not self.n_path:
+            raise ValueError("n_path is not set. Call configure(n_path=...) first.")
+
         tobs = np.atleast_1d(tobs)
-        path = self._bm_incr(tobs, n_path)
+        path = self._bm_incr(tobs, self.n_path)
         np.cumsum(path, axis=0, out=path)
 
         if store:
-            self.n_path = n_path
             self.path = path
             self.tobs = tobs
+            return self
         else:
             return path
 
     def price_european(self, spot, texp, payoff):
         """
-        The European price of that payoff at the expiry.
+        Price a European payoff using stored paths.
 
         Args:
             spot: array of spot prices
-            texp: time-to-expiry
-            payoff: payoff function applicable to the time-slice of price path
+            texp: time-to-expiry (must be one of the stored tobs)
+            payoff: function of the (path, asset) slice at texp
 
         Returns:
-            The MC price of the payoff
+            discounted MC price
         """
-        if self.n_path == 0:
-            raise ValueError("Simulated paths are not available. Run simulate() first.")
+        if self.path is None:
+            raise ValueError("No paths stored. Call simulate() first.")
 
-        # check if texp is in tobs
         ind, *_ = np.where(np.isclose(self.tobs, texp))
         if len(ind) == 0:
             raise ValueError(f"Stored tobs does not contain t={texp}")
 
         path = self.path[ind[0], ] + spot
-        price = np.exp(-self.intr * texp) * np.mean(payoff(path), axis=0)
-        return price
+        return np.exp(-self.intr * texp) * np.mean(payoff(path), axis=0)

--- a/pyfeng/nsvh.py
+++ b/pyfeng/nsvh.py
@@ -273,7 +273,6 @@ class NsvhMc(NsvhABC):
         self.__post_init__()
         return self
 
-    set_num_params = configure
 
     def mc_vol_price(self, texp):
         """

--- a/pyfeng/nsvh.py
+++ b/pyfeng/nsvh.py
@@ -2,6 +2,7 @@ import numpy as np
 import scipy.stats as spst
 import scipy.special as spsp
 import scipy.optimize as spop
+from dataclasses import dataclass, field
 
 from .opt_abc import OptABC
 from .util import MathFuncs, MathConsts
@@ -223,6 +224,7 @@ class Nsvh1(NsvhABC):
         self.sigma = np.sqrt(2 * var / ((ww_root - 1) * m2base)) * self.vov
 
 
+@dataclass
 class NsvhMc(NsvhABC):
     """
     Monte-Carlo model of Hyperbolic Normal Stochastic Volatility (NSVh) model.
@@ -249,17 +251,29 @@ class NsvhMc(NsvhABC):
         array([-0.00328887,  0.00523714,  0.00808885,  0.0069694 ,  0.00205566])
     """
 
-    n_path = int(16e4)
-    rn_seed = None
-    rng = np.random.default_rng(None)
-    antithetic = True
+    n_path:     int  = field(default=160000, kw_only=True, metadata={'kind': 'numerical'})
+    rn_seed:    int  = field(default=None,   kw_only=True, metadata={'kind': 'numerical'})
+    antithetic: bool = field(default=True,   kw_only=True, metadata={'kind': 'numerical'})
 
-    def set_num_params(self, n_path=1e6, rn_seed=None, antithetic=True):
-        self.n_path = int(n_path)
-        self.rn_seed = rn_seed
-        self.antithetic = antithetic
-        self.rn_seed = rn_seed
-        self.rng = np.random.default_rng(rn_seed)
+    def __post_init__(self):
+        super().__post_init__()
+        self.rngs = [np.random.default_rng(np.random.SeedSequence(self.rn_seed).spawn(1)[0])]
+
+    @property
+    def rng(self):
+        return self.rngs[0]
+
+    def configure(self, n_path=None, rn_seed=None, antithetic=None):
+        if n_path is not None:
+            self.n_path = int(n_path)
+        if rn_seed is not None:
+            self.rn_seed = rn_seed
+        if antithetic is not None:
+            self.antithetic = antithetic
+        self.__post_init__()
+        return self
+
+    set_num_params = configure
 
     def mc_vol_price(self, texp):
         """
@@ -278,7 +292,7 @@ class NsvhMc(NsvhABC):
         vol_var = self.vov**2 * texp
         vol_std = np.sqrt(vol_var)
 
-        z_rn = self.rng.normal(size=(int(self.n_path / 2), 3))
+        z_rn = self.rngs[0].normal(size=(int(self.n_path / 2), 3))
         z_rn = np.stack([z_rn, -z_rn], axis=1).reshape((-1, 3))
         z_rn[:, 2] += 0.5 * (self.lam - 1) * vol_std  # add shift
 

--- a/pyfeng/ousv.py
+++ b/pyfeng/ousv.py
@@ -1,8 +1,10 @@
 import abc
+from dataclasses import dataclass
 import warnings
 import numpy as np
 import scipy.special as spsp
 import scipy.integrate as scint
+from dataclasses import dataclass, field
 from .sv_abc import CondMcBsmABC
 from .opt_abc import OptABC
 from . import bsm
@@ -368,6 +370,7 @@ class OusvUncorrBallRoma1994(OusvABC):
         return price
 
 
+@dataclass
 class OusvMcABC(OusvABC, CondMcBsmABC):
 
     @abc.abstractmethod
@@ -520,6 +523,7 @@ class OusvMcABC(OusvABC, CondMcBsmABC):
         return var_r / texp  # annualized
 
 
+@dataclass
 class OusvMcTimeDisc(OusvMcABC):
     """
     OUSV model with conditional Monte-Carlo simulation
@@ -580,6 +584,7 @@ class OusvMcTimeDisc(OusvMcABC):
         return vol_t, avgvar, avgvol
 
 
+@dataclass
 class OusvMcChoi2025KL(OusvMcABC):
     """
     Exact Monte Carlo simulation for the OUSV model using Karhunen–Loève (KL) expansions.
@@ -617,7 +622,7 @@ class OusvMcChoi2025KL(OusvMcABC):
         >>> import numpy as np
         >>> import pyfeng as pf
         >>> m = pf.OusvMcChoi2025KL(sigma=0.2, vov=0.1, mr=4, rho=-0.7, theta=0.2)
-        >>> m.set_num_params(n_path=100000, dt=None, rn_seed=42, n_sin=4)
+        >>> m.configure(n_path=100000, dt=None, rn_seed=42, n_sin=4)
         >>> m.price(np.arange(80, 121, 10), spot=100, texp=1)
 
     References:
@@ -627,9 +632,14 @@ class OusvMcChoi2025KL(OusvMcABC):
           https://doi.org/10.1016/j.orl.2025.107280
     """
 
-    n_sin = 2
+    n_sin: int = field(default=2, kw_only=True, metadata={'kind': 'numerical'})
 
-    def set_num_params(self, n_path=10000, dt=None, rn_seed=None, antithetic=True, n_sin=2):
+    def __post_init__(self):
+        if self.n_sin % 2 != 0:
+            raise ValueError(f"n_sin must be an even integer, got {self.n_sin}.")
+        super().__post_init__()
+
+    def configure(self, n_path=None, dt=None, rn_seed=None, antithetic=None, n_sin=None):
         """
         Set Monte Carlo parameters.
 
@@ -643,11 +653,13 @@ class OusvMcChoi2025KL(OusvMcABC):
                 even integer). Higher values reduce the truncation error at the
                 cost of slightly more computation. Default is 2.
         """
-        if n_sin % 2 != 0:
-            raise ValueError(f"n_sin must be an even integer, got {n_sin}.")
-        self.n_sin = n_sin
+        if n_sin is not None:
+            if n_sin % 2 != 0:
+                raise ValueError(f"n_sin must be an even integer, got {n_sin}.")
+            self.n_sin = n_sin
 
-        super().set_num_params(n_path, dt, rn_seed, antithetic)
+        super().configure(n_path, dt, rn_seed, antithetic)
+        return self
 
     @classmethod
     def _a2sum(cls, mr_t, ns=0, odd=None):
@@ -928,14 +940,14 @@ class OusvMcChoi2025KL(OusvMcABC):
 
             if self.antithetic:
                 n_path_half = int(n_path//2)
-                z_sin = self.rng_spawn[2].standard_normal(size=(n_path_half, n_sin)).T
+                z_sin = self.rngs[2].standard_normal(size=(n_path_half, n_sin)).T
                 z_sin = np.stack([z_sin, -z_sin], axis=-1).reshape((n_sin, n_path))
 
-                z_gpqr = self.rng_spawn[1].standard_normal(size=(n_path_half, 4)).T
+                z_gpqr = self.rngs[1].standard_normal(size=(n_path_half, 4)).T
                 z_gpqr = np.stack([z_gpqr, -z_gpqr], axis=-1).reshape((4, n_path))
             else:
-                z_sin = self.rng_spawn[2].standard_normal(size=(n_path, n_sin)).T
-                z_gpqr = self.rng_spawn[1].standard_normal(size=(n_path, 4)).T
+                z_sin = self.rngs[2].standard_normal(size=(n_path, n_sin)).T
+                z_gpqr = self.rngs[1].standard_normal(size=(n_path, 4)).T
 
             # Create views to array rows
             z_g = z_gpqr[0, :]
@@ -1049,7 +1061,7 @@ class OusvMcChoi2025KL(OusvMcABC):
 
         if zn is None:
             vol_t = self.vol_step(dt, vol_0, nz_theta=False)
-            zn = self.rng_spawn[2].standard_normal(size=(self.n_sin, self.n_path))
+            zn = self.rngs[2].standard_normal(size=(self.n_sin, self.n_path))
             n_sin, n_path = self.n_sin, self.n_path
         else:
             vol_t = self.vol_step(dt, vol_0, zn[0, :], nz_theta=False)

--- a/pyfeng/params.py
+++ b/pyfeng/params.py
@@ -50,12 +50,15 @@ from typing import ClassVar
 def _params_kw(obj) -> dict:
     """Return a dict of all *init* fields, keyword-only fields last.
 
-    Excludes ``field(init=False)`` entries (precomputed constants).
+    Excludes ``field(init=False)`` entries (precomputed constants) and
+    fields with ``metadata={'kind': 'numerical'}`` (numerical/MC parameters).
     Keyword-only fields (``intr``, ``divr``, ``is_fwd``) are sorted to the end
     so the dict reads in natural model-parameter order.
     """
-    positional = {f.name: getattr(obj, f.name) for f in dataclasses.fields(obj) if f.init and not f.kw_only}
-    kw_only    = {f.name: getattr(obj, f.name) for f in dataclasses.fields(obj) if f.init and f.kw_only}
+    def _is_model(f):
+        return f.init and f.metadata.get('kind') != 'numerical'
+    positional = {f.name: getattr(obj, f.name) for f in dataclasses.fields(obj) if _is_model(f) and not f.kw_only}
+    kw_only    = {f.name: getattr(obj, f.name) for f in dataclasses.fields(obj) if _is_model(f) and f.kw_only}
     return {**positional, **kw_only}
 
 
@@ -81,6 +84,12 @@ class BaseParams:
     # None (default) means derive from model_type: ``{model_type.lower()}_benchmark.xlsx``.
     # Override with a literal filename in subclasses that share another model's benchmark file.
     _benchmark_file: ClassVar[str] = None
+
+    def __post_init__(self):
+        # Cooperative base: propagate to the next __post_init__ in the MRO if present.
+        _next = getattr(super(), '__post_init__', None)
+        if _next is not None:
+            _next()
 
     def params_kw(self) -> dict:
         """Model parameters as a keyword-argument dictionary."""
@@ -215,6 +224,7 @@ class CevParams(BaseParams):
             raise ValueError(f"beta must be > 0, got {self.beta}")
         if self.beta == 1.0:
             raise ValueError(f"beta = 1 is not allowed (use the BSM model instead)")
+        super().__post_init__()
 
 
 # ──────────────────────────────────────────────────────────────────────────────
@@ -239,7 +249,9 @@ class SabrParams(CevParams):
     rho: float = 0.0
 
     def __post_init__(self):
-        pass  # SABR allows beta=0 (Normal) and beta=1 (lognormal)
+        # SABR allows beta=0 (Normal) and beta=1 (lognormal); skip CevParams validation.
+        # Call BaseParams.__post_init__ directly to continue the cooperative chain.
+        BaseParams.__post_init__(self)
 
 
 # ──────────────────────────────────────────────────────────────────────────────
@@ -263,6 +275,7 @@ class SvParams(BaseParams):
     def __post_init__(self):
         if self.theta is None:
             self.theta = self.sigma
+        super().__post_init__()
 
 
 

--- a/pyfeng/sabr_mc.py
+++ b/pyfeng/sabr_mc.py
@@ -1,4 +1,5 @@
 import math
+from dataclasses import dataclass
 import abc
 import warnings
 import numpy as np
@@ -7,6 +8,7 @@ import scipy.stats as spst
 import scipy.special as spsp
 from functools import partial
 import scipy.integrate as scint
+from dataclasses import dataclass, field
 from . import sabr
 from .sv_abc import CondMcBsmABC
 
@@ -15,6 +17,7 @@ from .sv_abc import CondMcBsmABC
 # 2: integrated/average variance (lognormal)
 # 5: asset return
 
+@dataclass
 class SabrMcABC(sabr.SabrABC, CondMcBsmABC):
 
     def vol_step(self, dt, log=False):
@@ -135,6 +138,7 @@ class SabrMcABC(sabr.SabrABC, CondMcBsmABC):
         return price
 
 
+@dataclass
 class SabrMcTimeDisc(SabrMcABC):
     """
     Conditional MC for SABR model (beta=0,1 or rho=0) with conditional Monte-Carlo simulation
@@ -264,6 +268,7 @@ class SabrMcTimeDisc(SabrMcABC):
         return None
 
 
+@dataclass
 class SabrMcCai2017Exact(SabrMcABC):
     """
     Cai et al. (2017)'s exact simulation of the SABR model
@@ -271,13 +276,20 @@ class SabrMcCai2017Exact(SabrMcABC):
     References:
         - Cai N, Song Y, Chen N (2017) Exact Simulation of the SABR Model. Oper Res 65:931–951. https://doi.org/10.1287/opre.2017.1617
     """
-    m_inv = 20
-    m_euler = 20
-    n_euler = 35
-    comb_coef = None
-    nn = None
+    m_inv:   int = field(default=20, kw_only=True, metadata={'kind': 'numerical'})
+    m_euler: int = field(default=20, kw_only=True, metadata={'kind': 'numerical'})
+    n_euler: int = field(default=35, kw_only=True, metadata={'kind': 'numerical'})
 
-    def set_num_params(self, n_path=10000, dt=None, rn_seed=None, antithetic=True, m_inv=20, m_euler=20, n_euler=35):
+    def _init_euler_coefs(self):
+        self.comb_coef = spsp.comb(self.m_euler, np.arange(0, self.m_euler+0.1)) * np.power(0.5, self.m_euler)
+        assert abs(self.comb_coef.sum()-1) < 1e-8
+        self.nn = np.arange(0, self.m_euler + self.n_euler + 0.1)
+
+    def __post_init__(self):
+        super().__post_init__()
+        self._init_euler_coefs()
+
+    def configure(self, n_path=None, dt=None, rn_seed=None, antithetic=None, m_inv=None, m_euler=None, n_euler=None):
         """
         Set MC parameters
 
@@ -290,13 +302,15 @@ class SabrMcCai2017Exact(SabrMcABC):
             m_euler: parameter m in Euler transformation E(m,n)
             n_euler: parameter n in Euler transformation E(m,n)
         """
-        self.m_inv = m_inv
-        self.m_euler = m_euler
-        self.n_euler = n_euler
-        self.comb_coef = spsp.comb(self.m_euler, np.arange(0, self.m_euler+0.1)) * np.power(0.5, self.m_euler)
-        assert abs(self.comb_coef.sum()-1) < 1e-8
-        self.nn = np.arange(0, self.m_euler + self.n_euler + 0.1)
-        super().set_num_params(n_path, dt, rn_seed, antithetic)
+        if m_inv is not None:
+            self.m_inv = m_inv
+        if m_euler is not None:
+            self.m_euler = m_euler
+        if n_euler is not None:
+            self.n_euler = n_euler
+        super().configure(n_path, dt, rn_seed, antithetic)
+        self._init_euler_coefs()
+        return self
 
 
     def cond_laplace(self, theta, vovn, sigma_t):

--- a/pyfeng/sv32_mc.py
+++ b/pyfeng/sv32_mc.py
@@ -189,11 +189,11 @@ class Sv32McTimeStep(Sv32McABC):
             var_t = self.var_step_euler(var_0, dt, milstein=milstein)
         elif self.scheme == 2:
             # Euler (or Milstein) scheme
-            var_t = self.cir.draw_ncx2(dt, 1 / var_0, self.rng_spawn[0])
+            var_t = self.cir.draw_ncx2(dt, 1 / var_0, self.rngs[0])
             np.divide(1.0, var_t, out=var_t)
         elif self.scheme == 3:
             # Euler (or Milstein) scheme
-            var_t, _ = self.cir.draw_pois_gamma(dt, 1 / var_0, self.rng_spawn[0], self.rng_spawn[1])
+            var_t, _ = self.cir.draw_pois_gamma(dt, 1 / var_0, self.rngs[0], self.rngs[1])
             np.divide(1.0, var_t, out=var_t)
         else:
             raise ValueError(f'Invalid scheme: {self.scheme}')
@@ -286,7 +286,7 @@ class Sv32McBaldeaux2012Exact(Sv32McABC):
             tuple, variance at maturity and conditional integrated variance
         """
 
-        var_t = self.cir.draw_ncx2(dt, 1 / var_0, self.rng_spawn[0])
+        var_t = self.cir.draw_ncx2(dt, 1 / var_0, self.rngs[0])
         np.divide(1.0, var_t, out=var_t)
 
         avgvar = self.draw_cond_avgvar(dt, var_0, var_t)
@@ -315,9 +315,9 @@ class Sv32McChoiKwok2023Ig(Sv32McBaldeaux2012Exact):
         var_scaled = var_scaled[idx]
 
         if dist.lower() == 'ig':
-            avgvar[idx] = self.rng_spawn[1].wald(mean=mean, scale=mean / var_scaled)
+            avgvar[idx] = self.rngs[1].wald(mean=mean, scale=mean / var_scaled)
         elif dist.lower() == 'ga':
-            avgvar[idx] = var_scaled * mean * self.rng_spawn[1].standard_gamma(shape=1 / var_scaled)
+            avgvar[idx] = var_scaled * mean * self.rngs[1].standard_gamma(shape=1 / var_scaled)
         elif dist.lower() == 'ln':
             scale = np.sqrt(np.log1p(var_scaled))
             avgvar[idx] = mean * np.exp(scale * (self.rv_normal(spawn=1) - scale / 2))
@@ -359,7 +359,7 @@ class Sv32McChoiKwok2023Ig(Sv32McBaldeaux2012Exact):
             tuple, variance at maturity and conditional integrated variance
         """
 
-        var_t, eta = self.cir.draw_pois_gamma(texp, 1 / var_0, self.rng_spawn[0], self.rng_spawn[1])
+        var_t, eta = self.cir.draw_pois_gamma(texp, 1 / var_0, self.rngs[0], self.rngs[1])
 
         np.divide(1.0, var_t, out=var_t)
         # print('eta', eta.min(), eta.mean(), eta.max())
@@ -409,7 +409,7 @@ class Sv32McChoiKwok2023Ig(Sv32McBaldeaux2012Exact):
             (var_t, avgvar)
         """
 
-        var_t = self.cir.draw_ncx2(dt, 1/var_0, self.rng_spawn[0])
+        var_t = self.cir.draw_ncx2(dt, 1/var_0, self.rngs[0])
         np.divide(1.0, var_t, out=var_t)
         m1, var_scaled = self.cond_avgvar_mv(dt, var_0, var_t, eta=None)
         avgvar = self.draw_from_mv(m1, var_scaled, self.dist)

--- a/pyfeng/sv_abc.py
+++ b/pyfeng/sv_abc.py
@@ -1,24 +1,33 @@
 import numpy as np
 import abc
+from dataclasses import dataclass, field
+from typing import ClassVar
 from . import bsm
 from .opt_abc import OptABC
 
 
+@dataclass
 class CondMcBsmABC(OptABC):
     """
     Abstract Class for conditional Monte-Carlo method for BSM-based stochastic volatility models
     """
 
-    dt = 0.05
-    n_path = 10000
-    rn_seed = None
-    rng = np.random.default_rng(None)
-    rng_spawn = []
-    antithetic = True
-    correct_fwd = False
-    result = {}
+    n_path:     int   = field(default=10000, kw_only=True, metadata={'kind': 'numerical'})
+    dt:         float = field(default=0.05,  kw_only=True, metadata={'kind': 'numerical'})
+    rn_seed:    int   = field(default=None,  kw_only=True, metadata={'kind': 'numerical'})
+    antithetic: bool  = field(default=True,  kw_only=True, metadata={'kind': 'numerical'})
+    correct_fwd: ClassVar[bool] = False
 
-    def set_num_params(self, n_path=10000, dt=0.25, rn_seed=None, antithetic=True):
+    def __post_init__(self):
+        seed_seq = np.random.SeedSequence(self.rn_seed)
+        self.rngs = [np.random.default_rng(s) for s in seed_seq.spawn(7)]
+        self.result = {}
+
+    @property
+    def rng(self):
+        return self.rngs[0]
+
+    def configure(self, n_path=None, dt=None, rn_seed=None, antithetic=None):
         """
         Set MC parameters
 
@@ -28,15 +37,19 @@ class CondMcBsmABC(OptABC):
             rn_seed: random number seed
             antithetic: antithetic
         """
-        self.n_path = int(n_path)
-        self.dt = dt
-        self.rn_seed = rn_seed
-        self.antithetic = antithetic
+        if n_path is not None:
+            self.n_path = int(n_path)
+        if dt is not None:
+            self.dt = dt
+        if rn_seed is not None:
+            self.rn_seed = rn_seed
+        if antithetic is not None:
+            self.antithetic = antithetic
 
-        self.rng = np.random.default_rng(rn_seed)
-        seed_seq = np.random.SeedSequence(rn_seed)
-        self.rng_spawn = [np.random.default_rng(s) for s in seed_seq.spawn(6)]
-        self.result = {}
+        self.__post_init__()
+        return self
+
+    set_num_params = configure
 
     def base_model(self, vol):
         return bsm.Bsm(vol, intr=self.intr, divr=self.divr, is_fwd=self.is_fwd)
@@ -60,18 +73,18 @@ class CondMcBsmABC(OptABC):
 
     def rv_normal(self, spawn=0):
         if self.antithetic:
-            zz = self.rng_spawn[spawn].standard_normal(size=self.n_path // 2)
+            zz = self.rngs[spawn].standard_normal(size=self.n_path // 2)
             zz = np.stack([zz, -zz], axis=1).flatten()
         else:
-            zz = self.rng_spawn[spawn].standard_normal(size=self.n_path)
+            zz = self.rngs[spawn].standard_normal(size=self.n_path)
         return zz
 
     def rv_uniform(self, spawn=0):
         if self.antithetic:
-            zz = self.rng_spawn[spawn].uniform(size=self.n_path // 2)
+            zz = self.rngs[spawn].uniform(size=self.n_path // 2)
             zz = np.stack([zz, 1-zz], axis=1).flatten()
         else:
-            zz = self.rng_spawn[spawn].uniform(size=self.n_path)
+            zz = self.rngs[spawn].uniform(size=self.n_path)
         return zz
 
     def _bm_incr(self, tobs, cum=False, n_path=None):
@@ -95,10 +108,10 @@ class CondMcBsmABC(OptABC):
         if self.antithetic:
             # generate random number in the order of (path, time) first and transposed
             # in this way, the same paths are generated when increasing n_path
-            bm_incr = self.rng_spawn[0].standard_normal((int(n_path // 2), n_dt)).T * np.sqrt(dt[:, None])
+            bm_incr = self.rngs[0].standard_normal((int(n_path // 2), n_dt)).T * np.sqrt(dt[:, None])
             bm_incr = np.stack([bm_incr, -bm_incr], axis=1).reshape((-1, n_path))
         else:
-            bm_incr = self.rng_spawn[0].standard_normal(n_path, n_dt).T * np.sqrt(dt[:, None])
+            bm_incr = self.rngs[0].standard_normal(n_path, n_dt).T * np.sqrt(dt[:, None])
 
         if cum:
             np.cumsum(bm_incr, axis=0, out=bm_incr)

--- a/pyfeng/sv_abc.py
+++ b/pyfeng/sv_abc.py
@@ -49,7 +49,6 @@ class CondMcBsmABC(OptABC):
         self.__post_init__()
         return self
 
-    set_num_params = configure
 
     def base_model(self, vol):
         return bsm.Bsm(vol, intr=self.intr, divr=self.divr, is_fwd=self.is_fwd)

--- a/pyfeng/sv_fin_diff.py
+++ b/pyfeng/sv_fin_diff.py
@@ -163,7 +163,6 @@ class SvFinDiffABC(abc.ABC):
         self.__post_init__()
         return self
 
-    set_num_params = configure
 
     # ── Abstract interface ────────────────────────────────────────────────────
 

--- a/pyfeng/sv_fin_diff.py
+++ b/pyfeng/sv_fin_diff.py
@@ -35,6 +35,7 @@ Credits:
 
 import abc
 import numpy as np
+from dataclasses import dataclass, field
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -119,6 +120,7 @@ def _standard_bc(V, kk, X, cp):
 # Generic ADI mixin ABC
 # ─────────────────────────────────────────────────────────────────────────────
 
+@dataclass
 class SvFinDiffABC(abc.ABC):
     """
     Generic Douglas-scheme 2D ADI mixin for stochastic-volatility models.
@@ -135,14 +137,18 @@ class SvFinDiffABC(abc.ABC):
     ``price()`` handles forward/discount scaling externally.
     """
 
-    # Default numerical parameters — override via set_num_params()
+    # Numerical parameters as kw_only dataclass fields
     # n_grid = (N_time, M_price, L_vol); matches BENCHOP-SLV convention M = 2L, N ≈ L
-    n_grid:    tuple = (80, 80, 40)
-    adi_theta: float = 0.5
+    n_grid:    tuple = field(default=(80, 80, 40), kw_only=True, metadata={'kind': 'numerical'})
+    adi_theta: float = field(default=0.5,          kw_only=True, metadata={'kind': 'numerical'})
 
-    def set_num_params(self, n_grid=(80, 80, 40), adi_theta=0.5):
+    def __post_init__(self):
+        self.n_grid    = tuple(int(x) for x in self.n_grid)
+        self.adi_theta = float(self.adi_theta)
+
+    def configure(self, n_grid=None, adi_theta=None):
         """
-        Configure the ADI grid (consistent with ``set_num_params`` in *_mc.py).
+        Configure the ADI grid.
 
         Args:
             n_grid:    (N_time, M_price, L_vol) — number of time steps and
@@ -150,8 +156,14 @@ class SvFinDiffABC(abc.ABC):
                        BENCHOP-SLV convention: M = 2L, N ≈ L.
             adi_theta: Douglas weight; 0.5 → Crank–Nicolson accuracy
         """
-        self.n_grid    = tuple(int(x) for x in n_grid)
-        self.adi_theta = float(adi_theta)
+        if n_grid is not None:
+            self.n_grid = n_grid
+        if adi_theta is not None:
+            self.adi_theta = adi_theta
+        self.__post_init__()
+        return self
+
+    set_num_params = configure
 
     # ── Abstract interface ────────────────────────────────────────────────────
 
@@ -383,6 +395,7 @@ from .heston import HestonABC, HestonCevABC  # noqa: E402
 # SABR concrete pricer
 # ─────────────────────────────────────────────────────────────────────────────
 
+@dataclass
 class SabrFinDiff(SvFinDiffABC, SabrABC):
     """
     European SABR option pricing via 2D Douglas ADI finite differences.
@@ -429,6 +442,7 @@ class SabrFinDiff(SvFinDiffABC, SabrABC):
 # Heston concrete pricer
 # ─────────────────────────────────────────────────────────────────────────────
 
+@dataclass
 class HestonFinDiff(SvFinDiffABC, HestonABC):
     """
     European Heston option pricing via 2D Douglas ADI finite differences.
@@ -513,6 +527,7 @@ class HestonFinDiff(SvFinDiffABC, HestonABC):
 # CEV-Heston concrete pricer
 # ─────────────────────────────────────────────────────────────────────────────
 
+@dataclass
 class HestonCevFinDiff(HestonCevABC, HestonFinDiff):
     """
     European CEV-Heston option pricing via 2D Douglas ADI finite differences.

--- a/tests/test_cev.py
+++ b/tests/test_cev.py
@@ -164,8 +164,7 @@ class TestCevGreeks(unittest.TestCase):
         ]
         for params in cases:
             m_a = pf.Cev(**params)
-            m_mc = pf.CevMc(**params)
-            m_mc.set_num_params(n_path=200_000, dt=None, rn_seed=42)
+            m_mc = pf.CevMc(**params).configure(n_path=200_000, dt=None, rn_seed=42)
 
             for cp in (1, -1):
                 p_a  = m_a.price(strikes, spot, texp, cp)

--- a/tests/test_heston.py
+++ b/tests/test_heston.py
@@ -55,7 +55,7 @@ class TestHestonMc(unittest.TestCase):
         """
         for no in [1, 2, 3]:
             m, p, rv = pf.HestonMcAndersen2008.init_benchmark(no)
-            m.set_num_params(n_path=1e5, dt=1/8, rn_seed=123456)
+            m.configure(n_path=1e5, dt=1/8, rn_seed=123456)
             m.correct_fwd = False
 
             vol0 = pf.Bsm(None, intr=m.intr, divr=m.divr).impvol(rv['val'], **rv['args_pricing'])
@@ -65,14 +65,14 @@ class TestHestonMc(unittest.TestCase):
             np.testing.assert_allclose(m.result['spot error'], 0, atol=2e-3)
 
             m, *_ = pf.HestonMcGlassermanKim2011.init_benchmark(no)
-            m.set_num_params(n_path=1e5, rn_seed=123456, kk=10)
+            m.configure(n_path=1e5, rn_seed=123456, kk=10)
             m.correct_fwd = False
             vol1 = m.vol_smile(**rv['args_pricing'])
             np.testing.assert_allclose(vol0, vol1, atol=5e-3)
             np.testing.assert_allclose(m.result['spot error'], 0, atol=2e-3)
 
             m, *_ = pf.HestonMcTseWan2013.init_benchmark(no)
-            m.set_num_params(n_path=1e5, rn_seed=123456, dt=1)
+            m.configure(n_path=1e5, rn_seed=123456, dt=1)
             m.correct_fwd = False
             vol1 = m.vol_smile(**rv['args_pricing'])
             np.testing.assert_allclose(vol0, vol1, atol=5e-3)
@@ -80,12 +80,12 @@ class TestHestonMc(unittest.TestCase):
 
             m, *_ = pf.HestonMcChoiKwok2023PoisGe.init_benchmark(no)
             m.correct_fwd = False
-            m.set_num_params(n_path=1e5, rn_seed=123456, kk=10, dt=None)
+            m.configure(n_path=1e5, rn_seed=123456, kk=10, dt=None)
             vol1 = m.vol_smile(**rv['args_pricing'])
             np.testing.assert_allclose(vol0, vol1, atol=5e-3)
             np.testing.assert_allclose(m.result['spot error'], 0, atol=2e-3)
 
-            m.set_num_params(n_path=1e5, rn_seed=123456, kk=1, dt=1/4)
+            m.configure(n_path=1e5, rn_seed=123456, kk=1, dt=1/4)
             vol1 = m.vol_smile(**rv['args_pricing'])
             np.testing.assert_allclose(vol0, vol1, atol=5e-3)
             np.testing.assert_allclose(m.result['spot error'], 0, atol=2e-3)
@@ -96,7 +96,7 @@ class TestHestonMc(unittest.TestCase):
         """
         #sigma, vov, mr, rho, texp, spot = 0.04, 1, 0.5, -0.9, 10, 100
         m, *_ = pf.HestonMcChoiKwok2023PoisGe.init_benchmark(1)
-        m.set_num_params(n_path=32e4, rn_seed=123456, kk=8)
+        m.configure(n_path=32e4, rn_seed=123456, kk=8)
 
         for texp in (1.0, 3.0, 5.0):
             # analytic mean and variance

--- a/tests/test_multiasset.py
+++ b/tests/test_multiasset.py
@@ -119,8 +119,7 @@ class TestMultiAsset(unittest.TestCase):
         strikes = np.arange(80, 121, 10)
 
         # Test BsmNd
-        m = pf.BsmNdMc(sigma, rho=0.5, rn_seed=1234)
-        m.simulate(tobs=[texp], n_path=20000)
+        m = pf.BsmNdMc(sigma, rho=0.5).configure(n_path=20000, rn_seed=1234).simulate([texp])
         p = []
         for strike in strikes:
             p.append(m.price_european(spot, texp, payoff))
@@ -129,8 +128,7 @@ class TestMultiAsset(unittest.TestCase):
         np.testing.assert_almost_equal(p, p2)
 
         # Test NormNd
-        m = pf.NormNdMc(sigma * spot, rho=0.5, rn_seed=1234)
-        m.simulate(tobs=[texp], n_path=20000)
+        m = pf.NormNdMc(sigma * spot, rho=0.5).configure(n_path=20000, rn_seed=1234).simulate([texp])
         p = []
         for strike in strikes:
             p.append(m.price_european(spot, texp, payoff))

--- a/tests/test_multiasset.py
+++ b/tests/test_multiasset.py
@@ -183,8 +183,7 @@ class TestBsmBasketChoi2018(unittest.TestCase):
             (0.20, 0.10), rho=0.50,
             weight=np.array([1.0, -1.0]),
             intr=0.10, divr=0.05,
-        )
-        m.set_num_params(n_quad=[4])
+        ).configure(n_quad=[4])
         strike = np.arange(0.0, 4.1, 0.4)
         result = m.price(strike, np.array([100.0, 96.0]), texp=1.0)
         result2 = np.array([
@@ -207,8 +206,7 @@ class TestBsmBasketChoi2018(unittest.TestCase):
         ])
         result = np.zeros(len(rhos))
         for i, rho in enumerate(rhos):
-            m = pf.BsmBasketChoi2018((0.15, 0.30), rho=rho, weight=np.array([1.0, -1.0]))
-            m.set_num_params(lam=9)
+            m = pf.BsmBasketChoi2018((0.15, 0.30), rho=rho, weight=np.array([1.0, -1.0])).configure(lam=9)
             result[i] = m.price(100.0, spot, texp=1.0)
         np.testing.assert_almost_equal(result, result2, decimal=6)
 
@@ -218,8 +216,7 @@ class TestBsmBasketChoi2018(unittest.TestCase):
         N=4, T=5, S=100, w=1/4, sigma=40%, rho=50%, r=q=0.
         Fast prices with lam=9 differ from converged prices by at most 1.5e-4.
         """
-        m = pf.BsmBasketChoi2018(0.4 * np.ones(4), rho=0.5)
-        m.set_num_params(lam=9)
+        m = pf.BsmBasketChoi2018(0.4 * np.ones(4), rho=0.5).configure(lam=9)
         strike = np.arange(50, 151, 10, dtype=float)
         result = m.price(strike, 100.0 * np.ones(4), texp=5.0)
         result2 = np.array([
@@ -242,14 +239,12 @@ class TestBsmBasketChoi2018(unittest.TestCase):
         result2 = np.array([17.7569163, 21.6920965, 25.0292992, 28.0073695, 32.0412265])
         result = np.zeros(len(rhos))
         for i, rho in enumerate(rhos):
-            m = pf.BsmBasketChoi2018(0.4 * np.ones(4), rho=rho)
-            m.set_num_params(lam=9)
+            m = pf.BsmBasketChoi2018(0.4 * np.ones(4), rho=rho).configure(lam=9)
             result[i] = m.price(100.0, spot, texp=5.0)
         np.testing.assert_almost_equal(result, result2, decimal=3)
 
         # rho=0.95: M=8, coarser — test to 2 decimal places only
-        m = pf.BsmBasketChoi2018(0.4 * np.ones(4), rho=0.95)
-        m.set_num_params(lam=9)
+        m = pf.BsmBasketChoi2018(0.4 * np.ones(4), rho=0.95).configure(lam=9)
         np.testing.assert_almost_equal(m.price(100.0, spot, texp=5.0), 33.9186874, decimal=2)
 
 

--- a/tests/test_ousv.py
+++ b/tests/test_ousv.py
@@ -62,7 +62,7 @@ class TestOusvKL(unittest.TestCase):
         m, p, rv = pf.OusvMcChoi2025KL.init_benchmark(sheet_no)
         n_sin = 6
         n_path = 50
-        m.set_num_params(n_path=n_path, rn_seed=123456, n_sin=4, dt=None)
+        m.configure(n_path=n_path, rn_seed=123456, n_sin=4, dt=None)
 
         n_step = 10000
         t_grid = np.arange(0, n_step + 1) / n_step

--- a/tests/test_sabr.py
+++ b/tests/test_sabr.py
@@ -81,7 +81,7 @@ class TestSabr(unittest.TestCase):
         """
         for k in [19, 20]:  # can test 22 (Korn&Tang) also, but difficult to pass
             m, df, rv = pf.SabrMcTimeDisc.init_benchmark(k)
-            m.set_num_params(n_path=5e4, dt=0.05, rn_seed=1234)
+            m.configure(n_path=5e4, dt=0.05, rn_seed=1234)
             p = m.price(**rv["args_pricing"])
             np.testing.assert_allclose(p, rv["val"], rtol=1e-3)
 

--- a/tests/test_sv_fin_diff.py
+++ b/tests/test_sv_fin_diff.py
@@ -31,7 +31,7 @@ def test_sabr_adi_benchop(set_no):
     Tolerance: abs=3e-3 (consistent with the BENCHOP-SLV paper error budget).
     """
     m, df, info = pf.SabrFinDiff.init_benchmark(set_no)
-    m.set_num_params(n_grid=(80, 80, 40))
+    m.configure(n_grid=(80, 80, 40))
 
     args   = info["args_pricing"]
     prices = m.price(**args)
@@ -59,7 +59,7 @@ def test_heston_adi_benchop():
     tolerances require Richardson extrapolation or finer grids.
     """
     m, df, info = pf.HestonFinDiff.init_benchmark(10)
-    m.set_num_params(n_grid=(80, 80, 40))
+    m.configure(n_grid=(80, 80, 40))
 
     args   = info["args_pricing"]
     prices = m.price(**args)
@@ -78,7 +78,7 @@ def test_heston_adi_benchop():
 def test_sabr_put_call_parity():
     """SABR put-call parity: C − P = S₀ − K (r = 0)."""
     m, _, info = pf.SabrFinDiff.init_benchmark(20)
-    m.set_num_params(n_grid=(80, 80, 40))
+    m.configure(n_grid=(80, 80, 40))
 
     args = info["args_pricing"]
     S0 = args["spot"]; K = float(args["strike"][1])  # ATM strike
@@ -92,7 +92,7 @@ def test_sabr_put_call_parity():
 def test_heston_put_call_parity():
     """Heston put-call parity at ATM: C − P = S₀ − K (r = 0)."""
     m, _, info = pf.HestonFinDiff.init_benchmark(10)
-    m.set_num_params(n_grid=(80, 80, 40))
+    m.configure(n_grid=(80, 80, 40))
 
     args = info["args_pricing"]
     S0 = float(args["spot"]); K = float(args["strike"][1])  # ATM strike (K=100)
@@ -110,7 +110,7 @@ def test_heston_put_call_parity():
 def test_sabr_array_strikes():
     """price() should accept an ndarray of strikes and return the same shape."""
     m, _, info = pf.SabrFinDiff.init_benchmark(20)
-    m.set_num_params(n_grid=(80, 80, 40))
+    m.configure(n_grid=(80, 80, 40))
 
     args   = info["args_pricing"]
     prices = m.price(**args)
@@ -134,14 +134,12 @@ def test_degenerate_to_cev():
     strikes = np.array([0.8, 1.0, 1.2])
 
     # SABR with vov→0: effective CEV vol = m_sabr.sigma
-    m_sabr = pf.SabrFinDiff(sigma=0.3, vov=1e-4, rho=0.0, beta=beta)
-    m_sabr.set_num_params(n_grid=(80, 80, 40))
+    m_sabr = pf.SabrFinDiff(sigma=0.3, vov=1e-4, rho=0.0, beta=beta).configure(n_grid=(80, 80, 40))
     p_sabr = m_sabr.price(strikes, S0, texp, cp=1)
 
     # HestonCev with vov→0, strong mr: variance frozen at sigma=theta,
     # effective CEV vol = sqrt(m_hcev.sigma)
-    m_hcev = pf.HestonCevFinDiff(sigma=0.09, vov=1e-4, mr=100.0, theta=0.09, rho=0.0, beta=beta)
-    m_hcev.set_num_params(n_grid=(80, 80, 40))
+    m_hcev = pf.HestonCevFinDiff(sigma=0.09, vov=1e-4, mr=100.0, theta=0.09, rho=0.0, beta=beta).configure(n_grid=(80, 80, 40))
     p_hcev = m_hcev.price(strikes, S0, texp, cp=1)
 
     # Both converge to the same CEV: sigma_cev = m_sabr.sigma = sqrt(m_hcev.sigma)
@@ -159,7 +157,7 @@ def test_degenerate_to_cev():
 def test_heston_positive_price():
     """Heston ATM call is positive and finite."""
     m, _, info = pf.HestonFinDiff.init_benchmark(10)
-    m.set_num_params(n_grid=(80, 80, 40))
+    m.configure(n_grid=(80, 80, 40))
 
     args  = info["args_pricing"]
     price = m.price(float(args["strike"][1]), float(args["spot"]), args["texp"], cp=1)


### PR DESCRIPTION
## Summary

- **`set_num_params` → `configure()`**: All MC and finite-difference classes
  expose numerical/simulation params through `configure(...)` returning `self`,
  enabling compact chained construction:
      m = pf.HestonMcAndersen2008(sigma, vov=vov, mr=mr, rho=rho) \
            .configure(n_path=1e5, dt=1/8, rn_seed=123456)

- **`kw_only` dataclass fields** with `metadata={'kind': 'numerical'}`:
  Numerical params are excluded from `_params_kw()` / `from_model()` so
  cross-algorithm copies (e.g. SabrFinDiff.from_model(other)) work cleanly.

- **Per-instance RNG**: `rng` / `rng_spawn` merged into `rngs` list
  (seeded in `__post_init__`); `rng` property returns `rngs[0]`.
  Fixes the shared class-level RNG bug present in all MC classes.

- **`BsmNdMc` / `NormNdMc`**:
  - `configure(n_path, rn_seed, antithetic)` added; `n_path` is now class data.
  - `simulate(tobs)` takes only observation times; returns `self` for chaining.
  - Dropped erroneous `OptABC` inheritance (abstract `price` was never
    implemented, making the class uninstantiable — pre-existing bug).
  - Fixed shared class-level state bug for `n_path`, `path`, `tobs`, `rng`.

- **Tests and docstrings** updated throughout to use the new API.

## Test plan
- [ ] pytest tests/test_heston.py
- [ ] pytest tests/test_sabr.py
- [ ] pytest tests/test_cev.py
- [ ] pytest tests/test_ousv.py
- [ ] pytest tests/test_multiasset.py
- [ ] pytest tests/test_sv_fin_diff.py